### PR TITLE
fix: add useEffect to prevent constant fetching of latest.geojson

### DIFF
--- a/src/components/Layout/VariablePanel.js
+++ b/src/components/Layout/VariablePanel.js
@@ -220,7 +220,7 @@ const VariablePanel = (props) => {
           setLastUpdated(date)
         })
     } catch (ex) {
-      console.error('whoopsies: ' + ex)
+      console.error('Failed to fetch "latest.geojson": ' + ex)
     }
   }, []);
 


### PR DESCRIPTION
## Problem
VariablePanel attempts to fetch `latest.geojson` every single render cycle

<img width="1913" height="363" alt="Screenshot 2025-12-01 at 4 14 52 PM" src="https://github.com/user-attachments/assets/69e5c870-032f-4ac1-ba68-aadf6526de20" />

## Approach
* fix: add a `useEffect` when fetching `latest.geojson` will only perform the fetch on first render :+1:
    * Note that we also incur a [cost from AWS S3](https://aws.amazon.com/s3/pricing/) based on the number of these fetch requests (~$0.0004 / 1000 requests)

<img width="1920" height="357" alt="Screenshot 2025-12-01 at 4 17 11 PM" src="https://github.com/user-attachments/assets/cd51440e-aa1f-4ad6-924d-749d2b28995c" />

## How to Test
1. Open the developer console, select the Network tab
2. Navigate to http://deploy-preview-5--stirring-alpaca-574101.netlify.app/map
    * You should NOT see a bunch of requests fetching `latest.geojson` (you should see only one :+1:)
3. Compare with `main`: https://stirring-alpaca-574101.netlify.app/map