### PR TITLE
feat: pattern for displaying sticker/marker flag icons for AQ monitoring sites

### DIFF
--- a/public/content/stickers.json
+++ b/public/content/stickers.json
@@ -1,11 +1,52 @@
 [
-    {
-        "title": "Instituto Del Progreso Latino",
-        "subtitle": "Pilsen",
-        "icon": "../../icons/stickers/pilsen-icon.svg",
-        "logo": "../../icons/stickers/pilsen-logo.svg",
-        "long": -87.6885052,
-        "lat": 41.8457851,
-        "blog_slug": "designing-chives-with-instituto"
-    }
+  {
+    "title": "Washington High School",
+    "subtitle": "3535 E. 114th St",
+    "icon": "../../icons/stickers/noun-flag.svg",
+    "logo": "../../icons/stickers/noun-flag.svg",
+    "long": -87.5395,
+    "lat": 41.6872,
+    "pm25": true,
+    "no2": false
+  },
+  {
+    "title": "Com Ed",
+    "subtitle": "7801 Lawndale",
+    "icon": "../../icons/stickers/noun-flag.svg",
+    "logo": "../../icons/stickers/noun-flag.svg",
+    "long": -87.7135,
+    "lat": 41.7514,
+    "pm25": true,
+    "no2": true
+  },
+  {
+    "title": "Mayfair Pump Station",
+    "subtitle": "4850 Wilson Ave.",
+    "icon": "../../icons/stickers/noun-flag.svg",
+    "logo": "../../icons/stickers/noun-flag.svg",
+    "long": -87.7499,
+    "lat": 41.9655,
+    "pm25": true,
+    "no2": false
+  },
+  {
+    "title": "Springfield Pump Station",
+    "subtitle": "1745 N. Springfield Ave.",
+    "icon": "../../icons/stickers/noun-flag.svg",
+    "logo": "../../icons/stickers/noun-flag.svg",
+    "long": -87.7227,
+    "lat": 41.9127,
+    "pm25": true,
+    "no2": false
+  },
+  {
+    "title": "Kennedy near-road #2",
+    "subtitle": "Kennedy Expy & W. Webster Ave",
+    "icon": "../../icons/stickers/noun-flag.svg",
+    "logo": "../../icons/stickers/noun-flag.svg",
+    "long": -87.6744,
+    "lat": 41.9207,
+    "pm25": false,
+    "no2": true
+  }
 ]

--- a/public/icons/stickers/noun-flag.svg
+++ b/public/icons/stickers/noun-flag.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1200pt" height="1200pt" version="1.1" viewBox="0 0 1200 1200" xmlns="http://www.w3.org/2000/svg">
+ <path d="m291.98 33.328v1133.3h74.391v-561.14l541.64-267.71z"/>
+</svg>

--- a/src/components/Map/MapMarkerPopup.js
+++ b/src/components/Map/MapMarkerPopup.js
@@ -1,8 +1,5 @@
-import React, {useEffect, useState} from 'react';
 import {ContentContainer} from "../../styled_components";
-import remarkGfm from "remark-gfm";
 import MapMarkerPin from "./MapMarkerPin";
-import ReactMarkdown from "react-markdown";
 import styled from "styled-components";
 
 const FlexRow = styled.div`
@@ -38,47 +35,7 @@ const PopupBody = styled.p`
 
 // This component handles and formats the map tooltip info regarding the clicked Community Sticker.
 // The props passed to this component should contain a reference to the Sticker that was clicked
-const MapMarkerPopup = ({ sticker, truncLength = 50 }) => {
-    // Metadata from the CMS system
-    const [posts, setPosts] = useState([]);
-    const [post, setPost] = useState(undefined);
-
-    /** Fetch posts from CMS */
-    useEffect(() => {
-        fetch('/content/posts.json')
-          .then(response => response.json())
-          .then(posts => {
-              setPosts(posts);
-          });
-    }, []);
-
-    /** Find our desired post */
-    useEffect(() => {
-        if (sticker) {
-            const post = posts.find((post) => sticker?.blog_slug === post?.slug);
-            setPost(post);
-        } else {
-            setPost(undefined);
-        }
-    }, [posts, sticker, truncLength]);
-
-    /** Truncate post length, if necessary */
-    const [truncatedMd, setTruncatedMd] = useState('');
-    useEffect(() =>  {
-        // Split post content into words and coompare this to truncLength
-        const segments = post?.content?.split(" ");
-        if (segments?.length > truncLength) {
-            // Only use the first truncLength # of words
-            const truncatedText = segments?.slice(0, truncLength)?.join(" ");
-            // Ensure that truncated text always ends with ellipses
-            const suffix = truncatedText?.endsWith('.') ? '..' : '...';
-            setTruncatedMd(`${truncatedText}${suffix}`);
-        } else {
-            // If post contents are shorter than our configured truncLength, then show full post content
-            setTruncatedMd(post?.content);
-        }
-    }, [post]);
-
+const MapMarkerPopup = ({ sticker }) => {
     return (
         <>
             {sticker && <>
@@ -88,12 +45,12 @@ const MapMarkerPopup = ({ sticker, truncLength = 50 }) => {
                         <FlexCol>
                             <PopupTitle>{sticker?.title}</PopupTitle>
                             <PopupSubtitle>{sticker?.subtitle}</PopupSubtitle>
+
                         </FlexCol>
                     </FlexRow>
 
                     <PopupBody>
-                        <ReactMarkdown children={truncatedMd} remarkPlugins={[remarkGfm]}></ReactMarkdown>
-                        <a className={'read-more'} href={`/posts/${post?.slug}`} target={'_blank'}>Read more &rarr;</a>
+                      Monitors: {sticker?.pm25 && 'PM2.5'}  {sticker?.no2 && 'NO2'}
                     </PopupBody>
                 </ContentContainer>
             </>}

--- a/src/components/Map/MapSection.js
+++ b/src/components/Map/MapSection.js
@@ -1,5 +1,5 @@
 // general imports, state
-import React, {useState, useEffect, useRef, useCallback} from "react";
+import React, {useState, useEffect, useRef, useCallback, useMemo} from "react";
 import { useSelector } from "react-redux";
 import styled from "styled-components";
 
@@ -7,14 +7,14 @@ import styled from "styled-components";
 import { MapView, FlyToInterpolator } from "@deck.gl/core";
 import { GeoJsonLayer } from "@deck.gl/layers";
 import { fitBounds } from "@math.gl/web-mercator";
-import MapboxGLMap from "react-map-gl";
+import MapboxGLMap, {Marker, Popup} from "react-map-gl";
 import { DataFilterExtension, FillStyleExtension } from "@deck.gl/extensions";
 
 // component, action, util, and config import
 import MapTooltipContent from "./MapTooltipContent";
 import Geocoder from "./Geocoder";
 import { scaleColor } from "../../utils";
-import {colors, parsedOverlays, pm2_5Bins, pm2_5ColorMap} from "../../config";
+import {colors, loadStickers, parsedOverlays, pm2_5Bins, pm2_5ColorMap} from "../../config";
 import * as SVG from "../../config/svg";
 import "mapbox-gl/dist/mapbox-gl.css";
 import { useChivesData } from "../../hooks/useChivesData";
@@ -22,6 +22,8 @@ import { useChivesWorkerQuery } from "../../hooks/useChivesWorkerQuery";
 import { MapboxOverlay } from "@deck.gl/mapbox";
 import { useControl } from "react-map-gl";
 import MapOverlayTooltipContent from "./MapOverlayTooltipContent";
+import MapMarkerPin from "./MapMarkerPin";
+import MapMarkerPopup from "./MapMarkerPopup";
 
 function DeckGLOverlay(props) {
   const overlay = useControl(() => new MapboxOverlay(props));
@@ -175,7 +177,7 @@ function MapSection({ setViewStateFn = () => {}, bounds, geoids = [], showSearch
   const filterValues = useSelector((state) => state.filterValues);
   const use3d = useSelector((state) => state.use3d);
   // component state elements
-  // hover and highlight geographibes
+  // hover and highlight geographies
   const [hoverInfo, setHoverInfo] = useState({
     x: null,
     y: null,
@@ -187,8 +189,36 @@ function MapSection({ setViewStateFn = () => {}, bounds, geoids = [], showSearch
     y: null,
     object: null,
   });
-  const [censorPopupFeature, setCensorPopupFeature] = useState(null)
+  const [censorPopupFeature, setCensorPopupFeature] = useState(null);
 
+  // AQ monitoring stations as stickers (similar to ChiVes community stickers)
+  const [stickers, setStickers] = useState([]);
+  useEffect( () => {
+    loadStickers('/content/stickers.json').then(s => setStickers(s))
+  }, []);
+  const mapStickers = useMemo(() =>
+    stickers?.map((sticker, index) => (
+      <Marker
+        key={`marker-${index}`}
+        longitude={sticker.long||sticker.longitude}
+        latitude={sticker.lat||sticker.latitude}
+        anchor="bottom"
+        offset={[7, 8]}
+        onClick={e => {
+          // If we let the click event propagates to the map, it will immediately close the popup
+          // with `closeOnClick: true`
+          //e.originalEvent.stopPropagation();
+          setPopupInfo(null);
+          setPopupInfo(sticker);
+          console.log('clicked', e)
+        }}
+      >
+        <MapMarkerPin size={32} imgSrc={sticker?.icon} imgAlt={sticker?.title} />
+      </Marker>
+    )), [stickers]);
+
+
+  const [popupInfo, setPopupInfo] = useState(null);
   const mapRef = useRef(null);
 
   const handlePanMap = (viewState) => {
@@ -692,6 +722,21 @@ function MapSection({ setViewStateFn = () => {}, bounds, geoids = [], showSearch
           }
         }}
       >
+        {mapParams.overlays.includes('aq-monitoring-sites') && mapStickers}
+        {popupInfo && (
+          <Popup
+            anchor="top"
+            className="sticker-marker-popup"
+            closeOnClick={false}
+            closeOnMove={true}
+            maxWidth={'45vw'}
+            longitude={Number(popupInfo.long||popupInfo.longitude)}
+            latitude={Number(popupInfo.lat||popupInfo.latitude)}
+            onClose={() => setPopupInfo(null)}
+          >
+            <MapMarkerPopup sticker={popupInfo} />
+          </Popup>
+        )}
         <DeckGLOverlay
           interleaved={true}
           width={"100%"}


### PR DESCRIPTION
## Problem
Using instead of simple colored points for the AQ Monitoring overlay is confusing

We would like to use the Flag icon (provided by the Noun project) to indicate these sites instead

## Approach
* feat: reuse code from ChiVes Community Stickers to apply flag icon on map (instead of colored point)
    * note: points are still present for now to show that the `offset` for the icon is correct - these can be removed in the future
* feat: apply an `offset` to the map Marker such that the base of the flag icon intersects with the overlay point

<img width="1194" height="793" alt="Screenshot 2026-01-09 at 3 52 43 PM" src="https://github.com/user-attachments/assets/63acc37e-4edb-4cb3-b091-f9ae6186a1cd" />

Open Questions:
* Should we get rid of the colored points? If yes, we should probably color the flag icon. If not, we should disable clicking the point itself

## How to Test
1. Navigate to https://deploy-preview-6--stirring-alpaca-574101.netlify.app/map
2. Scroll down to the bottom of the VariablePanel
3. Expand the Data Overlays dropdown and enable "AQ Monitoring Sites"
    * You should see a Legend appear at the bottom of the Data Overlays section indicating the color map for AQ sites
    * You should see colored 5 points appear on the map (3 red, 1 yellow, 1 orange)
    * You should see a flag icon now extends from each point
    * TODO? You should see that flag color matches the legend provided in the VariablePanel 
4. Click on the flag icon
    * You should see the MapMarkerPopup appear
    * You should no longer see CMS-sourced data in the popup (as we see in ChiVes)
    * You should see the address of this monitoring site
    * You should see info about the types of monitors available at this site