### PR TITLE
style: mobile styling fixes/consistency

### DIFF
--- a/src/components/Layout/Navbar.js
+++ b/src/components/Layout/Navbar.js
@@ -139,7 +139,7 @@ export default function Nav({
               </Grid>}
             </Grid>
             {/* <Grid as={LButton} alignItems={'end'} justifyContent={'right'} onClick={logoClicked} style={{ cursor: largeScreen ? '' : 'pointer' }}> */}
-              <img width={largeScreen ? 477 : '100%'} src={'/icons/chiair-logo.svg'} alt={'Chicago Air Quality'} />
+              <img width={largeScreen ? 477 : '100%'} style={{ minWidth: largeScreen ? '' : '8rem' }} src={'/icons/chiair-logo.svg'} alt={'Chicago Air Quality'} />
             {/* </Grid> */}
           </Grid>
 

--- a/src/components/Layout/Navbar.js
+++ b/src/components/Layout/Navbar.js
@@ -63,7 +63,7 @@ const NavItems = styled.ul`
   }
 `;
 const NavContainer = styled.div`
-  padding: 4rem 6rem 0 6rem;
+  padding: ${({ $largeScreen }) => $largeScreen ? '4rem 6rem 0 6rem' : '6rem 0 0 0'};
   top:.5em;
   left:.5em;
   z-index:500;
@@ -89,7 +89,7 @@ const LButton = styled(Button)`
 const ContentContainer = styled.div`
     max-width: 1200px; /* Standard container width */
     margin: 0 auto;    /* Centering the container */
-    padding: 0 2rem;   /* Prevents text from touching edges */
+    padding: ${({ $largeScreen }) => $largeScreen ? '0 2rem' : '0'}; /* Prevents text from touching edges on larger screens */
     width: 100%;
     box-sizing: border-box;
 `;
@@ -114,21 +114,21 @@ export default function Nav({
   const loc = useLocation();
   const navigate = useNavigate();
 
-  //const [mobileNavOpen, setMobileNavOpen] = useState(false);
+  const [mobileNavOpen, setMobileNavOpen] = useState(false);
 
   const largeScreen = useMediaQuery('(min-width: 600px)');
-  // const logoClicked = () => {
-  //   if (largeScreen) { return; }
-  //   setMobileNavOpen(!mobileNavOpen)
-  // };
+  const logoClicked = () => {
+    if (largeScreen) { return; }
+    setMobileNavOpen(!mobileNavOpen)
+  };
 
   return (
     <>
-      <NavContainer style={style}>
-        <ContentContainer>
+      <NavContainer style={style} $largeScreen={largeScreen}>
+        <ContentContainer $largeScreen={largeScreen}>
           <Grid container justifyContent={largeScreen ? 'space-between' : 'center'} alignItems={'center'} flexDirection={largeScreen ? 'row' : 'column-reverse'}>
             <Grid size={5}>
-              {(largeScreen /*|| mobileNavOpen*/) && <Grid container justifyContent={'space-between'} alignItems={'center'} marginBottom={'2rem'}>
+              {(largeScreen || mobileNavOpen) && <Grid container justifyContent={'space-between'} alignItems={'center'} marginBottom={'2rem'}>
                 {/* <DropdownButton style={{ fontSize: largeScreen ? '24px' : '16px' }} ButtonComponent={LButton} label={'Eng'} options={['English', 'Español']} /> */}
                 <LButton style={{ fontSize: largeScreen ? '24px' : '16px' }} onClick={() => navigate('/')}><FaHome /></LButton>
                 {/*<DropdownButton buttonProps={{size:'large'}} ButtonComponent={LButton}  label={'Maps'} />
@@ -138,9 +138,9 @@ export default function Nav({
                 <LButton style={{ fontSize: largeScreen ? '24px' : '16px' }} onClick={() => navigate('/about')}>About</LButton>
               </Grid>}
             </Grid>
-            {/* <Grid as={LButton} alignItems={'end'} justifyContent={'right'} onClick={logoClicked} style={{ cursor: largeScreen ? '' : 'pointer' }}> */}
+            <Grid alignItems={'end'} justifyContent={'right'} onClick={logoClicked} style={{ cursor: largeScreen ? '' : 'pointer', padding: largeScreen ? '' : '2rem 4rem' }}>
               <img width={largeScreen ? 477 : '100%'} style={{ minWidth: largeScreen ? '' : '8rem' }} src={'/icons/chiair-logo.svg'} alt={'Chicago Air Quality'} />
-            {/* </Grid> */}
+            </Grid>
           </Grid>
 
           {/*<LogoButtonContainer aria-describedby={id} variant="outlined" onClick={handleClick} title={id} color="success">

--- a/src/components/Pages/About.js
+++ b/src/components/Pages/About.js
@@ -11,6 +11,7 @@ import AccordionSummary from "@mui/material/AccordionSummary";
 import Stack from "@mui/material/Stack";
 import Chip from "@mui/material/Chip";
 import {FaCaretDown, FaCaretRight} from "react-icons/fa";
+import {SectionHeader} from "../VariablePanel/SectionHeader";
 // import {NavLink, useNavigate} from "react-router-dom";
 
 const AboutPage = styled.div`
@@ -297,7 +298,7 @@ export default function About() {
     };
 
 
-    
+
     return (
        <AboutPage>
          <NavBar />
@@ -391,24 +392,15 @@ export default function About() {
          <GradientBackground $largeScreen={largeScreen} style={{ marginBottom: 0, paddingBottom: largeScreen ? '5rem' : '4rem' }}>
            <ContentContainer>
              <FAQTopDivider />
-             <FAQHeader $largeScreen={largeScreen}>
-               <FAQExpandButton $largeScreen={largeScreen} onClick={toggleAllFaqs}>
-                 {areAllFaqsExpanded ? 'Collapse all' : 'Expand all'}
-               </FAQExpandButton>
-               <FAQHeaderContent>
-                 <FAQHeaderText>
-                   <FAQHeaderTopRow $largeScreen={largeScreen}>Some</FAQHeaderTopRow>
-                   <FAQHeaderBottomRow $largeScreen={largeScreen}>
-                     Frequently Asked <FAQHeaderBottomAccent>Questions</FAQHeaderBottomAccent>
-                   </FAQHeaderBottomRow>
-                 </FAQHeaderText>
-                 <FAQHeaderIcon
-                   $largeScreen={largeScreen}
-                   src={'/icons/chiair/aq-resources-icon.svg'}
-                   alt={''}
-                 />
-               </FAQHeaderContent>
-             </FAQHeader>
+             <SectionHeader imgSrc={'/icons/chiair/aq-resources-icon.svg'}
+                            topRowText={'Some'}
+                            bottomRowTextBlack={'Frequently Asked'}
+                            bottomRowTextRed={'Questions'}
+                            style={{ marginBottom: '6rem' }}
+                            buttonOnClick={toggleAllFaqs}
+                            buttonText={areAllFaqsExpanded ? 'Collapse all' : 'Expand all'}
+             />
+
              <FAQFilterRow direction="row" spacing={1} justifyContent={'flex-end'} useFlexGap flexWrap={'wrap'}>
                <FAQFilterChip
                  clickable

--- a/src/components/Pages/About.js
+++ b/src/components/Pages/About.js
@@ -12,7 +12,6 @@ import Stack from "@mui/material/Stack";
 import Chip from "@mui/material/Chip";
 import {FaCaretDown, FaCaretRight} from "react-icons/fa";
 import {SectionHeader} from "../VariablePanel/SectionHeader";
-// import {NavLink, useNavigate} from "react-router-dom";
 
 const AboutPage = styled.div`
     background:white;
@@ -38,66 +37,6 @@ const FAQTopDivider = styled.hr`
     margin: 2.75rem 0 5.375rem;
     border: 0;
     border-top: 1px solid #41B6E6;
-`;
-
-const FAQHeader = styled.div`
-    display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
-    gap: 2rem;
-    flex-direction: ${({ $largeScreen }) => $largeScreen ? 'row' : 'column-reverse'};
-`;
-
-const FAQExpandButton = styled.button`
-    border: 0;
-    padding: 0;
-    background: transparent;
-    color: #005899;
-    cursor: pointer;
-    font-family: Lexend,sans-serif;
-    font-size: ${({ $largeScreen }) => $largeScreen ? '24px' : '16px'};
-    line-height: 1.2;
-`;
-
-const FAQHeaderContent = styled.div`
-    display: flex;
-    align-items: flex-start;
-    justify-content: flex-end;
-    gap: 1rem;
-    margin-left: auto;
-`;
-
-const FAQHeaderText = styled.div`
-    display: flex;
-    flex-direction: column;
-    align-items: flex-end;
-    gap: 0.25rem;
-    text-align: right;
-`;
-
-const FAQHeaderTopRow = styled.div`
-    color: #444444;
-    font-family: Lexend,sans-serif;
-    font-size: ${({ $largeScreen }) => $largeScreen ? '32px' : '18px'};
-    font-weight: 400;
-    line-height: 1.1;
-`;
-
-const FAQHeaderBottomRow = styled.div`
-    color: #444444;
-    font-family: Lexend,sans-serif;
-    font-size: ${({ $largeScreen }) => $largeScreen ? '32px' : '18px'};
-    font-weight: 700;
-    line-height: 1.1;
-`;
-
-const FAQHeaderBottomAccent = styled.span`
-    color: #E4002B;
-`;
-
-const FAQHeaderIcon = styled.img`
-    width: ${({ $largeScreen }) => $largeScreen ? '100px' : '42px'};
-    height: auto;
 `;
 
 const FAQFilterRow = styled(Stack)`

--- a/src/components/Pages/Home.js
+++ b/src/components/Pages/Home.js
@@ -29,13 +29,15 @@ const HeroSectionInner = styled.div`
     padding-bottom: 6.5rem;
 `;
 const HeroArtwork = styled.div`
-    position: relative;
+    position: absolute;
+    bottom: ${({ $largeScreen }) => $largeScreen ? '6.5rem' : '4rem'};
+    opacity: ${({ $xlScreen }) => $xlScreen ? '' : '0.2'};
     width: 100%;
     min-height: ${({ $largeScreen }) => $largeScreen ? '38rem' : '27rem'};
-    margin-bottom: -6.5rem;
+    margin-bottom: ${({ $largeScreen }) => $largeScreen ? '-6.5rem' : '-4.5rem' };
     transform: ${({ $largeScreen }) => $largeScreen ? 'translateY(1.25rem)' : 'translateY(0.75rem)'};
     overflow: visible;
-    z-index: 0;
+    z-index: -1;
 `;
 const HeroLight = styled.img`
     position: absolute;
@@ -49,7 +51,7 @@ const HeroGroup = styled.img`
     position: absolute;
     left: -0.75rem;
     top: ${({ $largeScreen }) => $largeScreen ? '12.65rem' : '8.95rem'};
-    width: ${({ $largeScreen }) => $largeScreen ? '1.85rem' : '1.2rem'};
+    max-width: ${({ $largeScreen }) => $largeScreen ? '1.85rem' : '1.2rem'};
     height: auto;
     z-index: 2;
 `;
@@ -65,7 +67,7 @@ const HeroBench = styled.img`
     position: absolute;
     left: ${({ $largeScreen }) => $largeScreen ? '3.65rem' : '1.9rem'};
     bottom: ${({ $largeScreen }) => $largeScreen ? '-6.75rem' : '-3.25rem'};
-    width: ${({ $largeScreen }) => $largeScreen ? '35rem' : '22rem'};
+    width: ${({ $largeScreen, $tinyScreen }) => $largeScreen ? '35rem' : $tinyScreen ? '20rem' : '100%'};
     height: auto;
     z-index: 2;
 `;
@@ -236,7 +238,9 @@ const searchBandHeader6RightAnchor = 25.75;
 export default function Home() {
   const dispatch = useDispatch();
   const navigate = useNavigate();
+  const tinyScreen = useMediaQuery('(min-width: 300px)');
   const largeScreen = useMediaQuery('(min-width: 600px)');
+  const xlScreen = useMediaQuery('(min-width: 900px)');
 
   const sensorCount = 'over 275';
 
@@ -271,11 +275,11 @@ export default function Home() {
           <HeroSectionInner>
             <Grid container spacing={largeScreen ? 4 : 0} alignItems={'center'}>
               <Grid size={{ xs: 12, md: 6 }}>
-                <HeroArtwork $largeScreen={largeScreen}>
+                <HeroArtwork $largeScreen={largeScreen} $xlScreen={xlScreen}>
                   <HeroLight src={'/img/header/light.svg'} alt={''} $largeScreen={largeScreen} />
                   <HeroGroup src={'/img/header/group.svg'} alt={''} $largeScreen={largeScreen} />
                   <HeroWifi src={'/img/header/wifi.svg'} alt={''} $largeScreen={largeScreen} />
-                  <HeroBench src={'/img/header/bench.svg'} alt={''} $largeScreen={largeScreen} />
+                  <HeroBench src={'/img/header/bench.svg'} alt={''} $largeScreen={largeScreen} $tinyScreen={tinyScreen} />
                   <HeroSquirrel src={'/img/header/squirrel.svg'} alt={''} $largeScreen={largeScreen} />
                 </HeroArtwork>
               </Grid>
@@ -389,7 +393,7 @@ export default function Home() {
       <GradientBackground $largeScreen={largeScreen} style={{ marginBottom: 0 }}>
         <ContentContainer>
           <Grid container spacing={0} flexDirection={largeScreen ? 'row' : 'column-reverse'} justifyContent={'space-between'} alignItems={'flex-start'}>
-            <img style={{ maxWidth: '300px', maxHeight: '500px' }} src={'/icons/chiair/aq-network-large.svg'} alt={''} />
+            <img style={{ maxWidth: largeScreen ? '300px' : '100%', maxHeight: '500px' }} src={'/icons/chiair/aq-network-large.svg'} alt={''} />
             <Grid size={{ xs:12, md: 6 }} style={{ fontFamily: 'Space Grotesk', fontSize: '18px' }} alignItems={'center'} textAlign={'right'}>
               <Grid container spacing={0}>
                 <div>Traditional monitoring stations are miles apart, missing the pollution pockets that affect specific blocks. To close this gap, we deployed a fleet of {sensorCount} high-precision sensors to blanket the city.</div>
@@ -397,8 +401,8 @@ export default function Home() {
                 <div style={{ margin: '1rem 0 3rem' }}>This mapping application builds on that further, developed with community and cross-sector collaborations across Chicago to ensure the data is easily accessible, in context, and ready for action. <NavLink to={'/about'} style={{ textDecoration: 'none', color: '#005899', fontWeight: 700 }}>Learn more about us &rarr;</NavLink>.</div>{!largeScreen && <br/> }
               </Grid>
               <Grid container spacing={8} justifyContent={'right'} marginBottom={'4rem'}>
-                <img src={'/icons/chiair/uic-logo.svg'} alt={'UIC'} />
-                <img src={'/icons/chiair/uiuc-logo.svg'} alt={'UIUC'} />
+                <img src={'/icons/chiair/uic-logo.svg'} alt={'UIC'} style={{ maxWidth: '100%' }} />
+                <img src={'/icons/chiair/uiuc-logo.svg'} alt={'UIUC'} style={{ maxWidth: '100%' }} />
               </Grid>
             </Grid>
           </Grid>

--- a/src/components/Pages/Team.js
+++ b/src/components/Pages/Team.js
@@ -2,8 +2,9 @@ import styled from 'styled-components';
 import { NavBar } from '../../components';
 import Grid from "@mui/material/Grid";
 import useMediaQuery from "@mui/material/useMediaQuery";
-import { FaExternalLinkAlt } from "react-icons/fa";
+import {FaArrowRight, FaExternalLinkAlt} from "react-icons/fa";
 import { GradientBackground, WhiteBackground } from "../VariablePanel/common";
+import {SectionHeader} from "../VariablePanel/SectionHeader";
 
 const TeamPage = styled.div`
     background:white;
@@ -319,24 +320,14 @@ export default function Team() {
       <WhiteBackground $largeScreen={largeScreen}>
         <ContentContainer>
           <TopDivider />
-          <Header $largeScreen={largeScreen}>
-            <ExpandButton $largeScreen={largeScreen} onClick={''}>
-              {/* Add "Contact Us ->" button here later */}
-            </ExpandButton>
-            <HeaderContent>
-              <HeaderText>
-                <HeaderTopRow $largeScreen={largeScreen}>Passionately built</HeaderTopRow>
-                <HeaderBottomRow $largeScreen={largeScreen}>
-                  With <HeaderBottomAccent>Collaboration</HeaderBottomAccent>
-                </HeaderBottomRow>
-              </HeaderText>
-              <HeaderIcon
-                $largeScreen={largeScreen}
-                src={'/icons/chiair/aq-team-collab.svg'}
-                alt={''}
-              />
-            </HeaderContent>
-          </Header>
+          <SectionHeader imgSrc={'/icons/chiair/aq-team-collab.svg'}
+                         topRowText={'Passionately built'}
+                         bottomRowTextBlack={'With'}
+                         bottomRowTextRed={'Collaboration'}
+          />
+          {/*buttonOnClick={() => navigate('/contact')}*/}
+          {/*buttonText={'Contact Us'}*/}
+          {/*buttonIcon={<FaArrowRight style={{ marginLeft: '.5rem' }} />}*/}
 
           <CategorySection>
             <CategoryTitle $largeScreen={largeScreen}>Leadership</CategoryTitle>
@@ -390,21 +381,12 @@ export default function Team() {
       </WhiteBackground>
 
       <ContentContainer>
-        <Header $largeScreen={largeScreen}>
-          <HeaderContent>
-            <HeaderText style={{ marginBottom: '6rem' }}>
-              <HeaderTopRow $largeScreen={largeScreen}>Co-created with</HeaderTopRow>
-              <HeaderBottomRow $largeScreen={largeScreen}>
-                The <HeaderBottomAccent>Community</HeaderBottomAccent>
-              </HeaderBottomRow>
-            </HeaderText>
-            <HeaderIcon
-              $largeScreen={largeScreen}
-              src={'/icons/chiair/aq-team-community.svg'}
-              alt={''}
-            />
-          </HeaderContent>
-        </Header>
+        <SectionHeader imgSrc={'/icons/chiair/aq-team-community.svg'}
+                       topRowText={'Co-created with'}
+                       bottomRowTextBlack={'The'}
+                       bottomRowTextRed={'Community'}
+                       style={{ marginBottom: '6rem' }}
+        />
       </ContentContainer>
       <ContentContainer>
         <Grid container spacing={8} marginBottom={8} alignItems={'start'} rowSpacing={4}>

--- a/src/components/Pages/Team.js
+++ b/src/components/Pages/Team.js
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 import { NavBar } from '../../components';
 import Grid from "@mui/material/Grid";
 import useMediaQuery from "@mui/material/useMediaQuery";
-import {FaArrowRight, FaExternalLinkAlt} from "react-icons/fa";
+import {FaExternalLinkAlt} from "react-icons/fa";
 import { GradientBackground, WhiteBackground } from "../VariablePanel/common";
 import {SectionHeader} from "../VariablePanel/SectionHeader";
 
@@ -30,66 +30,6 @@ const TopDivider = styled.hr`
     margin: 2.75rem 0 5.375rem;
     border: 0;
     border-top: 1px solid #41B6E6;
-`;
-
-const Header = styled.div`
-    display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
-    gap: 2rem;
-    flex-direction: ${({ $largeScreen }) => $largeScreen ? 'row' : 'column-reverse'};
-`;
-
-const ExpandButton = styled.button`
-    border: 0;
-    padding: 0;
-    background: transparent;
-    color: #005899;
-    cursor: pointer;
-    font-family: Lexend,sans-serif;
-    font-size: ${({ $largeScreen }) => $largeScreen ? '24px' : '16px'};
-    line-height: 1.2;
-`;
-
-const HeaderContent = styled.div`
-    display: flex;
-    align-items: flex-start;
-    justify-content: flex-end;
-    gap: 1rem;
-    margin-left: auto;
-`;
-
-const HeaderText = styled.div`
-    display: flex;
-    flex-direction: column;
-    align-items: flex-end;
-    gap: 0.25rem;
-    text-align: right;
-`;
-
-const HeaderTopRow = styled.div`
-    color: #444444;
-    font-family: Lexend,sans-serif;
-    font-size: ${({ $largeScreen }) => $largeScreen ? '32px' : '18px'};
-    font-weight: 400;
-    line-height: 1.1;
-`;
-
-const HeaderBottomRow = styled.div`
-    color: #444444;
-    font-family: Lexend,sans-serif;
-    font-size: ${({ $largeScreen }) => $largeScreen ? '32px' : '18px'};
-    font-weight: 700;
-    line-height: 1.1;
-`;
-
-const HeaderBottomAccent = styled.span`
-    color: #E4002B;
-`;
-
-const HeaderIcon = styled.img`
-    width: ${({ $largeScreen }) => $largeScreen ? '100px' : '42px'};
-    height: auto;
 `;
 
 const CategorySection = styled.section`

--- a/src/components/VariablePanel/SectionHeader.js
+++ b/src/components/VariablePanel/SectionHeader.js
@@ -25,6 +25,10 @@ const ChiRedText = styled.span`
     font-weight: 700;
     text-align: right;
 `;
+const SectionIcon = styled.img`
+    width: ${({ $largeScreen }) => $largeScreen ? '100px' : '42px'};
+    height: auto;
+`
 
 export const SectionHeader = ({ style = {}, buttonIcon = <></>, buttonText = '', buttonOnClick, topRowText = '', bottomRowTextBlack = '', bottomRowTextRed = '', imgSrc, imgAlt = '' }) => {
   const largeScreen = useMediaQuery('(min-width: 600px)');
@@ -37,11 +41,13 @@ export const SectionHeader = ({ style = {}, buttonIcon = <></>, buttonText = '',
 
       <Grid container alignItems={'center'} spacing={8}>
         <ChiBlackText spacing={0} style={{ fontSize: largeScreen ? '32px': '18px', fontWeight: 400, textAlign: 'right' }}>
-          <Grid container spacing={4} alignItems={'center'} justifyContent={'right'}>
-            <Grid alignItems={'right'}>
+          <Grid container spacing={2} alignItems={'center'} justifyContent={'right'}>
+            <Grid alignItems={'right'} size={{ xs: 10 }}>
               {topRowText} <div style={{ fontWeight:700 }}>{bottomRowTextBlack} <ChiRedText>{bottomRowTextRed}</ChiRedText></div>
             </Grid>
-            <img width={largeScreen ? 100 : 42} src={imgSrc} alt={imgAlt} />
+            <Grid size={{ xs: 2 }}>
+              <SectionIcon width={largeScreen ? 100 : 42} src={imgSrc} alt={imgAlt} />
+            </Grid>
           </Grid>
         </ChiBlackText>
       </Grid>


### PR DESCRIPTION
## Problem
Minor fixes are needed for mobile styling across various views

Fixes #66
Fixes #56 
Fixes #23 
Fixes #22 

## Approach
* style: adjust the CSS of Hero images to react to screen size
    * if screen gets too small, increase opacity and move it to the background
* style: reuse `<SectionHeader>` component for consistent CSS styling across desktop/mobile view
* fix: restore click behavior of Navbar - this allows mobile users to toggle the Navbar view to save screen space

### Desktop
<img width="1363" height="832" alt="Screenshot 2026-04-13 at 1 14 38 PM" src="https://github.com/user-attachments/assets/c88aeed3-b777-4da1-a3d4-d37ac90a7d09" />

### Mobile
<img width="543" height="721" alt="Screenshot 2026-04-13 at 1 14 28 PM" src="https://github.com/user-attachments/assets/2f98d906-2790-4bf0-8bd2-b3448a329cbf" />

After logo clicked, we show the NavBar:
<img width="537" height="721" alt="Screenshot 2026-04-13 at 1 15 35 PM" src="https://github.com/user-attachments/assets/e356b217-0ecd-4869-b01b-eb23d465c8c4" />
