### PR TITLE
fix: broken Resource links on Home page

### DIFF
--- a/src/components/Pages/Home.js
+++ b/src/components/Pages/Home.js
@@ -364,7 +364,7 @@ export default function Home() {
         <Grid container spacing={8} marginBottom={16} alignItems={'start'} rowSpacing={4}>
           {resources?.map((resource, index) =>
             <Grid key={'resources-'+index} size={{ xs: 12, md: 3 }} style={{ cursor: 'pointer' }}
-                  onClick={() => navigate(resource?.url)}
+                  onClick={() => window.open(resource?.url, '_blank')}
                   justifyItems={'center'}>
               <Grid container spacing={0} marginY={'1rem'}>
                 <img style={{ marginRight: '2rem'  }} src={'/icons/chiair/resources-backlayer.svg'} alt={''} />


### PR DESCRIPTION
## Problem
The resource links on the Home page do not work

Fixes #77 

## Approach
* fix: we appear to be using `navigate()` for these calls. Since `navigate()` is only for relative URLs, the right pattern might be to use `window.open()` to open these links in a new tab

## How to Test
1. Navigate to the Home page
2. Scroll down to the Resources section
3. Click on a Resource
    * You should see that a new tab is opened in your browser to the URL for this resource