### PR TITLE
fix: disable AverageTypes if an invalid row index is found

### DIFF
--- a/src/components/VariablePanel/Panels/ClickedSensorDetailsPanel.js
+++ b/src/components/VariablePanel/Panels/ClickedSensorDetailsPanel.js
@@ -1,7 +1,7 @@
 import {useDispatch, useSelector} from "react-redux";
 import {
   selectAverageType,
-  selectClickedSensor, selectMetricData,
+  selectClickedSensor, selectMetricData, selectMetricIndex,
   selectMetrics, selectSensorGeojsonData, selectSensorLocations, selectSensorParameter,
   setAverageType, setSensorParameter
 } from "../../../store/slices/sensorDataSlice";
@@ -64,6 +64,7 @@ export const ClickedSensorDetailsPanel = ({ push, pop }) => {
   const metricData = useSelector(selectMetricData);
   const geojsonData = useSelector(selectSensorGeojsonData);
   const metrics = useSelector(selectMetrics);
+  const metricIndex = useSelector(selectMetricIndex);
 
   const setSelectedParameter = (payload) => dispatch(setSensorParameter(payload));
 
@@ -181,11 +182,11 @@ export const ClickedSensorDetailsPanel = ({ push, pop }) => {
               onChange={(e) => dispatch(setAverageType(e.target.value))}
             >
               <MenuItem value="hour">Hour</MenuItem>
-              <MenuItem value="day">Day</MenuItem>
-              <MenuItem value="week">Week</MenuItem>
-              <MenuItem value="month">Month</MenuItem>
-              <MenuItem value="season">Season</MenuItem>
-              <MenuItem value="year">Year</MenuItem>
+              <MenuItem value="day" disabled={metricIndex.day <= 0}>Day</MenuItem>
+              <MenuItem value="week" disabled={metricIndex.week <= 0}>Week</MenuItem>
+              <MenuItem value="month" disabled={metricIndex.month <= 0} title={'hello world'}>Month</MenuItem>
+              <MenuItem value="season" disabled={metricIndex.season <= 0}>Season</MenuItem>
+              <MenuItem value="year" disabled={metricIndex.year <= 0}>Year</MenuItem>
             </Select>
           </FormControl>
         </Grid>


### PR DESCRIPTION
## Problem
Several of the Average Types offered don't actually have any values to display yet

This could be confusing to users, who may think the app is just broken when the graph disappears

Fixes #95 

## Approach
* feat: disable any options from this dropdown that has an invalid row index
    * for `type==hour`: a non-zero index is considered invalid
    * for any other `type`: a zero index is considered invalid

<img width="457" height="731" alt="Screenshot 2026-05-13 at 5 09 08 PM" src="https://github.com/user-attachments/assets/68793596-e323-4f59-9c99-21d174833902" />



## How to Test
1. Navigate to /map
2. Click a sensor point
3. Click Details on the panel to the right
4. On the bottom, expand the Parameter dropdown and choose "NO2"
5. Next to this dropdown, expand the "View By" dropdown
    * You should see that some of the options are disabled