### PR TITLE
style: design audit 2026-05-14

### DIFF
--- a/src/components/Layout/GoogleTranslate.js
+++ b/src/components/Layout/GoogleTranslate.js
@@ -49,11 +49,14 @@ export const GoogleTranslate = () => {
     if (locale === previous) { console.log('locale unchanged.');return; }
 
     console.log('Setting locale to: ', locale);
-    if (!locale || locale === 'en') {
-      removeCookie('googtrans');
-    } else {
+
+    // FIXME: removeCookie does not work in Safari
+
+    // if (!locale || locale === 'en') {
+    //   removeCookie('googtrans', { path: '/', domain: 'localhost' });
+    // } else {
       setCookie('googtrans', `/auto/${locale}`, { path: '/' })
-    }
+    // }
 
     setTimeout(() => {
       window.location.reload();

--- a/src/components/Layout/Navbar.js
+++ b/src/components/Layout/Navbar.js
@@ -11,7 +11,7 @@ import {selectPanelState, setPanelState} from '../../store/slices/legacyStoreSli
 import * as SVG from '../../config/svg';
 import Grid from "@mui/material/Grid";
 import {DropdownButton} from "../VariablePanel/DropdownButton";
-import {FaHome} from "react-icons/fa";
+import {MdHomeFilled} from "react-icons/md";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import {setLocale} from "../../store/slices/sensorDataSlice";
 import {useCookies} from "react-cookie";
@@ -144,7 +144,7 @@ export default function Nav({
             <Grid size='grow'>
               {(largeScreen || mobileNavOpen) && <Grid spacing={2} container justifyContent={largeScreen ? 'initial' : 'center'} alignItems={'center'}>
                 <DropdownButton style={{ fontSize }} ButtonComponent={LButton} label={cookies['googtrans'] === '/auto/es' ? 'Español' : 'English'} options={[{label:'English', value:'en'}, {label:'Español',value:'es'}]} onChange={onLocaleChange} />
-                <LButton style={{ fontSize }} onClick={() => navigate('/')}><FaHome /></LButton>
+                <LButton style={{ fontSize }} onClick={() => navigate('/')}><MdHomeFilled /></LButton>
                 <NavDropdown key={'about'} label={'Maps & more'} style={{ fontSize }}>
                   <MenuItem as={LButton} onClick={() => navigate('/map')}>Our Air Map</MenuItem>
                   <MenuItem as={LButton} onClick={() => navigate('/resources')}>All Resources</MenuItem>

--- a/src/components/Map/DataPanel.js
+++ b/src/components/Map/DataPanel.js
@@ -190,7 +190,7 @@ const DataPanel = ({ mapRef }) => {
 
       {currentPage === 'root' && <>
         {(largeScreen || !clickedSensor) && <>
-          <Grid container spacing={2} alignItems={'center'}>
+          <Grid container spacing={2} alignItems={'start'}>
             <Grid size={{ xs: 4 }}>
               <DropdownHeader htmlFor="paramSelect" size={'small'}>Indicator</DropdownHeader>
               <FormControl id="paramSelect" variant="outlined" fullWidth margin={'dense'} style={{
@@ -211,7 +211,7 @@ const DataPanel = ({ mapRef }) => {
                   {/*<MenuItem value="mean_bc">BC</MenuItem>*/}
                 </Select>
               </FormControl>
-              <LButton as={Grid} justifyContent={'start'} onClick={() => pushPage(['Explain'])}>
+              <LButton as={Grid} justifyContent={'start'} style={{ width: '2rem' }} onClick={() => pushPage(['Explain'])}>
                 <FaInfoCircle style={{ margin: '.5rem .2rem' }} color={'rgba(0, 88, 153, 0.5)'} size={'0.75rem'} />
               </LButton>
             </Grid>

--- a/src/components/Map/Geocoder.js
+++ b/src/components/Map/Geocoder.js
@@ -3,23 +3,19 @@ import {useCallback, useMemo, useState} from "react";
 import {createSearchParams, useNavigate} from "react-router-dom";
 import styled from "styled-components";
 import TextField from "@mui/material/TextField";
-import {FaSearch} from "react-icons/fa";
+import {FaSearch, FaTimes} from "react-icons/fa";
 import Autocomplete from "@mui/material/Autocomplete";
 import {debounce} from "@mui/material/utils";
 import {AreaSelectionDropdowns} from "../VariablePanel/Panels/AreaSelectionDropdowns";
 
 import parse from 'autosuggest-highlight/parse';
 import match from 'autosuggest-highlight/match';
+import IconButton from "@mui/material/IconButton";
 
 const MAPBOX_ACCESS_TOKEN = process.env.REACT_APP_MAPBOX_TOKEN;
 
 const GeocoderContainer = styled(Grid)`
     width: 100%;
-    // TODO: add margin to AutoComplete endAdornment (X button)
-    //.MuiAutocomplete-root {
-    //    margin-left: 0.675rem;
-    //    margin-right: 0.875rem;
-    //}
     .MuiAutocomplete-inputRoot {
         background:white;
         height:${({height, $variant}) => $variant === 'home' ? 48 : height||36}px;
@@ -112,6 +108,7 @@ export const Geocoder = ({ showSelectedAreas = true, onDropdownChange, placehold
             filterOptions={(x) => x}
             autoComplete
             clearOnEscape
+            clearIcon={<div style={{ display:'none', cursor: 'initial' }}></div>}
             inputValue={searchState.value}
             options={searchState.results || []}
             getOptionLabel={option => option.place_name}
@@ -152,13 +149,18 @@ export const Geocoder = ({ showSelectedAreas = true, onDropdownChange, placehold
               <TextField
                 {...params}
                 margin={isHomeVariant ? "none" : "dense"}
-                style={{ borderRadius: isHomeVariant ? '100px' : '5px', border: '1px solid rgba(0, 88, 153, 1)',
-                  marginLeft: '0.675rem', marginRight:'1rem' }}
+                style={{ borderRadius: isHomeVariant ? '100px' : '5px', border: '1px solid rgba(0, 88, 153, 1)' }}
                 placeholder={placeholder}
                 slotProps={{
-                  input: { ...params.InputProps, type: 'search', startAdornment:
-                      <FaSearch style={{color: 'rgba(0, 88, 153, 1)', marginLeft:'1.25rem' }}></FaSearch>
-                  }
+                  input: {
+                    ...params.InputProps,
+                    startAdornment:
+                      <FaSearch style={{color: 'rgba(0, 88, 153, 1)', marginLeft:'1.25rem', marginRight: '0.5rem' }}></FaSearch>,
+                    endAdornment:
+                      searchState?.value && <FaTimes style={{ color: 'rgba(0, 88, 153, 1)', cursor: 'pointer', marginLeft: '0.675rem', marginRight: '0.875rem' }}
+                                                     onClick={() => setSearchState({ value: '' })} />
+
+                  },
                 }}
                 onChange={(e) => {
                   setSearchState(prev => ({

--- a/src/components/Map/Geocoder.js
+++ b/src/components/Map/Geocoder.js
@@ -10,7 +10,6 @@ import {AreaSelectionDropdowns} from "../VariablePanel/Panels/AreaSelectionDropd
 
 import parse from 'autosuggest-highlight/parse';
 import match from 'autosuggest-highlight/match';
-import IconButton from "@mui/material/IconButton";
 
 const MAPBOX_ACCESS_TOKEN = process.env.REACT_APP_MAPBOX_TOKEN;
 

--- a/src/components/Map/Geocoder.js
+++ b/src/components/Map/Geocoder.js
@@ -15,6 +15,11 @@ const MAPBOX_ACCESS_TOKEN = process.env.REACT_APP_MAPBOX_TOKEN;
 
 const GeocoderContainer = styled(Grid)`
     width: 100%;
+    // TODO: add margin to AutoComplete endAdornment (X button)
+    //.MuiAutocomplete-root {
+    //    margin-left: 0.675rem;
+    //    margin-right: 0.875rem;
+    //}
     .MuiAutocomplete-inputRoot {
         background:white;
         height:${({height, $variant}) => $variant === 'home' ? 48 : height||36}px;
@@ -147,11 +152,12 @@ export const Geocoder = ({ showSelectedAreas = true, onDropdownChange, placehold
               <TextField
                 {...params}
                 margin={isHomeVariant ? "none" : "dense"}
-                style={{ borderRadius: isHomeVariant ? '100px' : '5px', border: '1px solid rgba(0, 88, 153, 1)' }}
+                style={{ borderRadius: isHomeVariant ? '100px' : '5px', border: '1px solid rgba(0, 88, 153, 1)',
+                  marginLeft: '0.675rem', marginRight:'1rem' }}
                 placeholder={placeholder}
                 slotProps={{
                   input: { ...params.InputProps, type: 'search', startAdornment:
-                      <FaSearch style={{color: 'rgba(0, 88, 153, 1)', marginLeft:'1.25rem'}}></FaSearch>
+                      <FaSearch style={{color: 'rgba(0, 88, 153, 1)', marginLeft:'1.25rem' }}></FaSearch>
                   }
                 }}
                 onChange={(e) => {

--- a/src/components/Map/Geocoder.js
+++ b/src/components/Map/Geocoder.js
@@ -151,7 +151,7 @@ export const Geocoder = ({ showSelectedAreas = true, onDropdownChange, placehold
                 placeholder={placeholder}
                 slotProps={{
                   input: { ...params.InputProps, type: 'search', startAdornment:
-                      <FaSearch style={{color: 'rgba(0, 88, 153, 1)', marginLeft:'10px'}}></FaSearch>
+                      <FaSearch style={{color: 'rgba(0, 88, 153, 1)', marginLeft:'1.25rem'}}></FaSearch>
                   }
                 }}
                 onChange={(e) => {

--- a/src/components/Pages/Home.js
+++ b/src/components/Pages/Home.js
@@ -269,7 +269,7 @@ export default function Home() {
     <>
       <NavBar />
 
-      <WhiteBackground $largeScreen={largeScreen} style={{ marginBottom: 0 }}>
+      <WhiteBackground $largeScreen={largeScreen} style={{ marginBottom: 0, marginTop: '4rem' }}>
         <ContentContainer>
           <HeroSectionInner>
             <Grid container spacing={largeScreen ? 4 : 0} alignItems={'center'}>

--- a/src/components/Pages/Home.js
+++ b/src/components/Pages/Home.js
@@ -138,7 +138,7 @@ const HeroButton = styled(Button)`
     letter-spacing: 0;
     text-transform: capitalize;
     min-width: 10rem;
-    height: 3.5rem;
+    height: 3rem;
     padding: 0 1.5rem;
 `;
 const SearchBand = styled.section`

--- a/src/components/Pages/Home.js
+++ b/src/components/Pages/Home.js
@@ -37,7 +37,7 @@ const HeroArtwork = styled.div`
     margin-bottom: ${({ $largeScreen }) => $largeScreen ? '-6.5rem' : '-4.5rem' };
     transform: ${({ $largeScreen }) => $largeScreen ? 'translateY(1.25rem)' : 'translateY(0.75rem)'};
     overflow: visible;
-    z-index: 100;
+    z-index: 3;
 `;
 const HeroLight = styled.img`
     position: absolute;
@@ -140,6 +140,7 @@ const HeroButton = styled(Button)`
     min-width: 10rem;
     height: 3rem;
     padding: 0 1.5rem;
+    z-index: 55;
 `;
 const SearchBand = styled.section`
     position: relative;

--- a/src/components/Pages/Home.js
+++ b/src/components/Pages/Home.js
@@ -289,7 +289,7 @@ export default function Home() {
                     Our<HeroTitleAccent>Air</HeroTitleAccent>
                   </HeroTitle>
                   <HeroKicker $largeScreen={largeScreen}>Mapping the Open Air Network</HeroKicker>
-                  <HeroKickerAccent $largeScreen={largeScreen}>Built for Chicago, with Chicago.</HeroKickerAccent>
+                  <HeroKickerAccent $largeScreen={largeScreen}>Built with Chicago, for Chicago.</HeroKickerAccent>
                   <HeroBody $largeScreen={largeScreen}>
                     Air pollution is often invisible, but its impact is real. Now, real-time air quality
                     data is available for every neighborhood, for every Chicagoan, ensuring you and your

--- a/src/components/Pages/Home.js
+++ b/src/components/Pages/Home.js
@@ -37,7 +37,7 @@ const HeroArtwork = styled.div`
     margin-bottom: ${({ $largeScreen }) => $largeScreen ? '-6.5rem' : '-4.5rem' };
     transform: ${({ $largeScreen }) => $largeScreen ? 'translateY(1.25rem)' : 'translateY(0.75rem)'};
     overflow: visible;
-    z-index: -1;
+    z-index: 100;
 `;
 const HeroLight = styled.img`
     position: absolute;
@@ -49,7 +49,7 @@ const HeroLight = styled.img`
 `;
 const HeroGroup = styled.img`
     position: absolute;
-    left: -0.75rem;
+    left: -0.3rem;
     top: ${({ $largeScreen }) => $largeScreen ? '12.65rem' : '8.95rem'};
     max-width: ${({ $largeScreen }) => $largeScreen ? '1.85rem' : '1.2rem'};
     height: auto;
@@ -57,8 +57,8 @@ const HeroGroup = styled.img`
 `;
 const HeroWifi = styled.img`
     position: absolute;
-    left: ${({ $largeScreen }) => $largeScreen ? '3.2rem' : '1.65rem'};
-    top: ${({ $largeScreen }) => $largeScreen ? '12rem' : '8.45rem'};
+    left: ${({ $largeScreen }) => $largeScreen ? '2.5rem' : '1.65rem'};
+    top: ${({ $largeScreen }) => $largeScreen ? '11.75rem' : '8.45rem'};
     width: ${({ $largeScreen }) => $largeScreen ? '1.95rem' : '1.25rem'};
     height: auto;
     z-index: 2;
@@ -69,7 +69,7 @@ const HeroBench = styled.img`
     bottom: ${({ $largeScreen }) => $largeScreen ? '-6.75rem' : '-3.25rem'};
     width: ${({ $largeScreen, $tinyScreen }) => $largeScreen ? '35rem' : $tinyScreen ? '20rem' : '100%'};
     height: auto;
-    z-index: 2;
+    z-index: 4;
 `;
 const HeroSquirrel = styled.img`
     position: absolute;

--- a/src/components/Pages/Home.js
+++ b/src/components/Pages/Home.js
@@ -93,6 +93,7 @@ const HeroTitle = styled.h1`
     font-family: Lexend,sans-serif;
     font-size: ${({ $largeScreen }) => $largeScreen ? '4rem' : '3rem'};
     font-weight: 400;
+    color: #444444;
     line-height: 1;
     margin: 0;
 `;

--- a/src/components/VariablePanel/Panels/AreaSelectionDropdowns.js
+++ b/src/components/VariablePanel/Panels/AreaSelectionDropdowns.js
@@ -19,7 +19,7 @@ import Box from "@mui/material/Box";
 import InputBase from "@mui/material/InputBase";
 
 const HomeDropdownCard = styled.div`
-  width: 100%;
+  width: 16rem;
   max-width: 45rem;
   margin: 0 auto;
   border-radius: 0.75rem;
@@ -164,21 +164,28 @@ export const AreaSelectionDropdowns = ({ showSelectedAreas = true, onChange, siz
     return [...new Set(locations?.filter(l => !!l[type])?.map(l => l[type]))];
   }, [type, locations]);
 
-  const filteredOptions = useMemo(() => {
-    const ops = options.map(o => {
-      const parts = o.split(' ').map(o => o[0]?.toUpperCase() + o.substring(1)?.toLowerCase())
-      console.log(parts);
-      return parts.join(' ');
-    });
+  const format = (value, type) => {
+    if (type === 'ward') {
+      return `Ward ${value}`;
+    } else if (type === 'community') {
+      return value[0]?.toUpperCase() + value.substring(1)?.toLowerCase()
+    }
+    return value;
+  }
 
+  const filteredOptions = useMemo(() => {
+    const ops = options.map(o => o.split(' ').map(o => format(o, type)).join(' '));
 
     if (!searchTerm) {
-      return type !== 'ward' ? ops.sort() : ops.sort((a, b) => Number(a) - Number(b));
+      return type !== 'ward' ? ops.sort() : ops.sort((a, b) => {
+        return Number(a?.split(' ')[1]) - Number(b?.split(' ')[1])
+      });
     }
 
     const normalizedSearch = searchTerm.toLowerCase();
-    return (type !== 'ward' ? ops.sort() : ops.sort((a, b) => Number(a) - Number(b)))
-      .filter((option) => option?.toLowerCase().includes(normalizedSearch));
+    return (type !== 'ward' ? ops.sort() : ops.sort((a, b) => {
+      return Number(a?.split(' ')[1]) - Number(b?.split(' ')[1])
+    })).filter((option) => option?.toLowerCase().includes(normalizedSearch));
   }, [options, searchTerm, type]);
 
   return(
@@ -228,7 +235,6 @@ export const AreaSelectionDropdowns = ({ showSelectedAreas = true, onChange, siz
 
                 return (
                   <HomeDropdownOption key={option} type="button" onClick={() => handleChange(option, type)}>
-                    {type==='ward' ? 'Ward ' : ''}
                     {parts.map((part, index) => (part.highlight ? (
                       <HomeDropdownHighlight key={index}>{part.text}</HomeDropdownHighlight>
                     ) : (

--- a/src/components/VariablePanel/Panels/AreaSelectionDropdowns.js
+++ b/src/components/VariablePanel/Panels/AreaSelectionDropdowns.js
@@ -164,11 +164,22 @@ export const AreaSelectionDropdowns = ({ showSelectedAreas = true, onChange, siz
     return [...new Set(locations?.filter(l => !!l[type])?.map(l => l[type]))];
   }, [type, locations]);
 
+  // When displaying, we need to transform / pretty print our possible values
   const format = (value, type) => {
     if (type === 'ward') {
       return `Ward ${value}`;
     } else if (type === 'community') {
       return value[0]?.toUpperCase() + value.substring(1)?.toLowerCase()
+    }
+    return value;
+  }
+
+  // When user selects an option, we need to undo the transformation above to select their choice
+  const unformat = (value, type) => {
+    if (type === 'ward') {
+      return value.split(' ')?.[1];
+    } else if (type === 'community') {
+      return value?.toUpperCase()
     }
     return value;
   }
@@ -234,7 +245,7 @@ export const AreaSelectionDropdowns = ({ showSelectedAreas = true, onChange, siz
                 const parts = parse(option, matches);
 
                 return (
-                  <HomeDropdownOption key={option} type="button" onClick={() => handleChange(option, type)}>
+                  <HomeDropdownOption key={option} type="button" onClick={() => handleChange(unformat(option, type), type)}>
                     {parts.map((part, index) => (part.highlight ? (
                       <HomeDropdownHighlight key={index}>{part.text}</HomeDropdownHighlight>
                     ) : (
@@ -253,7 +264,7 @@ export const AreaSelectionDropdowns = ({ showSelectedAreas = true, onChange, siz
             openOnFocus
             onBlur={handleClose}
             autoComplete
-            onChange={(e, s) => handleChange(s, type)}
+            onChange={(e, s) => handleChange(unformat(s, type), type)}
             clearOnEscape
             fullWidth
             clearIcon={undefined}

--- a/src/components/VariablePanel/Panels/AreaSelectionDropdowns.js
+++ b/src/components/VariablePanel/Panels/AreaSelectionDropdowns.js
@@ -85,7 +85,6 @@ const HomeDropdownOption = styled.button`
   text-align: left;
   cursor: pointer;
   color: #444444;
-  text-transform: capitalize;
   font-family: Space Grotesk,serif;
   font-size: 1rem;
   font-style: normal;
@@ -166,12 +165,19 @@ export const AreaSelectionDropdowns = ({ showSelectedAreas = true, onChange, siz
   }, [type, locations]);
 
   const filteredOptions = useMemo(() => {
+    const ops = options.map(o => {
+      const parts = o.split(' ').map(o => o[0]?.toUpperCase() + o.substring(1)?.toLowerCase())
+      console.log(parts);
+      return parts.join(' ');
+    });
+
+
     if (!searchTerm) {
-      return type !== 'ward' ? options.sort() : options.sort((a, b) => Number(a) - Number(b));
+      return type !== 'ward' ? ops.sort() : ops.sort((a, b) => Number(a) - Number(b));
     }
 
     const normalizedSearch = searchTerm.toLowerCase();
-    return (type !== 'ward' ? options.sort() : options.sort((a, b) => Number(a) - Number(b)))
+    return (type !== 'ward' ? ops.sort() : ops.sort((a, b) => Number(a) - Number(b)))
       .filter((option) => option?.toLowerCase().includes(normalizedSearch));
   }, [options, searchTerm, type]);
 
@@ -222,11 +228,12 @@ export const AreaSelectionDropdowns = ({ showSelectedAreas = true, onChange, siz
 
                 return (
                   <HomeDropdownOption key={option} type="button" onClick={() => handleChange(option, type)}>
-                    {parts.map((part, index) => part.highlight ? (
-                      <HomeDropdownHighlight key={index}>{part.text?.toLowerCase()}</HomeDropdownHighlight>
+                    {type==='ward' ? 'Ward ' : ''}
+                    {parts.map((part, index) => (part.highlight ? (
+                      <HomeDropdownHighlight key={index}>{part.text}</HomeDropdownHighlight>
                     ) : (
-                      <span key={index}>{part.text?.toLowerCase()}</span>
-                    ))}
+                      <span>{part.text}</span>
+                    )))}
                   </HomeDropdownOption>
                 );
               }) : <HomeDropdownEmpty>No options</HomeDropdownEmpty>}
@@ -236,7 +243,7 @@ export const AreaSelectionDropdowns = ({ showSelectedAreas = true, onChange, siz
 
         {type && !isHomeVariant && <Grid size={12} margin={'0 1rem'} padding={0} alignItems={'center'}>
           <Autocomplete
-            options={type !== 'ward' ? options.sort() : options.sort((a, b) => Number(a) - Number(b))}
+            options={filteredOptions}
             openOnFocus
             onBlur={handleClose}
             autoComplete

--- a/src/components/VariablePanel/Panels/AreaSelectionDropdowns.js
+++ b/src/components/VariablePanel/Panels/AreaSelectionDropdowns.js
@@ -190,8 +190,8 @@ export const AreaSelectionDropdowns = ({ showSelectedAreas = true, onChange, siz
 
   return(
     <>
-      {(noSelection || !showSelectedAreas) && <Grid container width={'100%'} justifyContent={isHomeVariant ? 'center' : 'space-around'} alignItems={'center'} columnGap={isHomeVariant ? 2 : 0} rowGap={isHomeVariant ? 1 : 0}>
-        {(isHomeVariant || !type) && [ 'community', 'zip', 'ward' ]?.map((key) => <Grid size key={key}>
+      {(noSelection || !showSelectedAreas) && <Grid style={{ position: 'relative' }} container width={'100%'} justifyContent={isHomeVariant ? 'center' : 'space-around'} alignItems={'center'} columnGap={isHomeVariant ? 2 : 0} rowGap={isHomeVariant ? 1 : 0}>
+        {[ 'community', 'zip', 'ward' ]?.map((key) => <Grid size key={key}>
           <LButton
             id={`basic-button-${key}`}
             size={'small'}
@@ -247,7 +247,7 @@ export const AreaSelectionDropdowns = ({ showSelectedAreas = true, onChange, siz
           </HomeDropdownCard>
         </Grid>}
 
-        {type && !isHomeVariant && <Grid size={12} margin={'0 1rem'} padding={0} alignItems={'center'}>
+        {type && !isHomeVariant && <Grid style={{ position: 'absolute', top: '32px' }} size={12} margin={'0 1rem'} padding={0} alignItems={'center'}>
           <Autocomplete
             options={filteredOptions}
             openOnFocus

--- a/src/components/VariablePanel/Panels/AreaSelectionDropdowns.js
+++ b/src/components/VariablePanel/Panels/AreaSelectionDropdowns.js
@@ -85,6 +85,7 @@ const HomeDropdownOption = styled.button`
   text-align: left;
   cursor: pointer;
   color: #444444;
+  text-transform: capitalize;
   font-family: Space Grotesk,serif;
   font-size: 1rem;
   font-style: normal;
@@ -177,7 +178,7 @@ export const AreaSelectionDropdowns = ({ showSelectedAreas = true, onChange, siz
   return(
     <>
       {(noSelection || !showSelectedAreas) && <Grid container width={'100%'} justifyContent={isHomeVariant ? 'center' : 'space-around'} alignItems={'center'} columnGap={isHomeVariant ? 2 : 0} rowGap={isHomeVariant ? 1 : 0}>
-        {!type && [ 'community', 'zip', 'ward' ]?.map((key) => <Grid size key={key}>
+        {(isHomeVariant || !type) && [ 'community', 'zip', 'ward' ]?.map((key) => <Grid size key={key}>
           <LButton
             id={`basic-button-${key}`}
             size={'small'}
@@ -222,9 +223,9 @@ export const AreaSelectionDropdowns = ({ showSelectedAreas = true, onChange, siz
                 return (
                   <HomeDropdownOption key={option} type="button" onClick={() => handleChange(option, type)}>
                     {parts.map((part, index) => part.highlight ? (
-                      <HomeDropdownHighlight key={index}>{part.text}</HomeDropdownHighlight>
+                      <HomeDropdownHighlight key={index}>{part.text?.toLowerCase()}</HomeDropdownHighlight>
                     ) : (
-                      <span key={index}>{part.text}</span>
+                      <span key={index}>{part.text?.toLowerCase()}</span>
                     ))}
                   </HomeDropdownOption>
                 );

--- a/src/components/VariablePanel/Panels/AreaSelectionDropdowns.js
+++ b/src/components/VariablePanel/Panels/AreaSelectionDropdowns.js
@@ -296,7 +296,7 @@ export const AreaSelectionDropdowns = ({ showSelectedAreas = true, onChange, siz
 
       {showSelectedAreas && (!noSelection || hasSelection) && <Grid container width={'100%'} spacing={0} margin={'0.3rem'} alignItems={'center'} display={'flex'} flexDirection={"row"} justifyContent={'space-between'} fontFamily={'Lexend'}>
         <Grid size>
-          {selections?.community?.length > 0 && <span><LLabel>Community:</LLabel> {selections?.community?.[0]}</span>}
+          {selections?.community?.length > 0 && <span><LLabel>Community:</LLabel> {format(selections?.community?.[0], 'community')}</span>}
           {selections?.zip?.length > 0 && <span><LLabel>Zip code:</LLabel> {selections?.zip?.[0]}</span>}
           {selections?.ward?.length > 0 && <span><LLabel>Ward:</LLabel> {selections?.ward?.[0]}</span>}
         </Grid>


### PR DESCRIPTION
## Problem
Another round of minor styling improvements for the homepage and some other related views/features

Fixes #97 

## Approach
Log and address through items in real time one by one during a Zoom meeting

List of items addressed are tracked in the [ticket comments](https://github.com/healthyregions/chi-air/issues/97#issuecomment-4453398188)

## How to Test
1. Navigate to https://deploy-preview-98--stirring-alpaca-574101.netlify.app/
    * You should see updated styling (minor) for the homepage
    * Notable changes are listed out in detail in #97
2. Test out the Geocoder on the homepage, as well as the dropdowns below it (Community, Zip code, Ward, etc)
    * You should see that Community + Ward have nicer styling, but the behavior should remain the same

### Safari only
1. Change language from English -> Spanish
    * Wait a few seconds for the page to translate - if it doesn't translate, then that is a problem.
2. Change language from Spanish -> English
    * Wait a few seconds for the page to translate - if it doesn't translate, then that is a problem.
3. Repeat this a few times and note the behavior
    * Ensure that this behavior works properly back and forth a few times, in case there are odd cookie/state issue in play