### PR TITLE
feat: added Polish (pl) and Mandarin (zh-CN) as language options

### DIFF
--- a/src/components/Layout/GoogleTranslate.js
+++ b/src/components/Layout/GoogleTranslate.js
@@ -3,6 +3,7 @@ import styled from "styled-components";
 import {useSelector} from "react-redux";
 import {selectLocale} from "../../store/slices/sensorDataSlice";
 import {useCookies} from "react-cookie";
+import {locales} from "../VariablePanel/common";
 
 const GoogleTranslateContainer = styled.div`
   position: fixed;
@@ -36,7 +37,7 @@ export const GoogleTranslate = () => {
     new window.google.translate.TranslateElement(
       {
         //pageLanguage: "en",
-        includedLanguages: "en,es",
+        includedLanguages: locales?.map(l => l.value)?.join(','),   // e.g.  "en,es,pl,zh-CN",
         autoDisplay: true
       },
       "google_translate_element"
@@ -50,13 +51,12 @@ export const GoogleTranslate = () => {
 
     console.log('Setting locale to: ', locale);
 
-    // FIXME: removeCookie does not work in Safari
-
-    // if (!locale || locale === 'en') {
-    //   removeCookie('googtrans', { path: '/', domain: 'localhost' });
-    // } else {
+    if (!locale || locale === 'auto') {
+      // FIXME: removeCookie does not appear to work in Safari
+      removeCookie('googtrans', { path: '/' });
+    } else {
       setCookie('googtrans', `/auto/${locale}`, { path: '/' })
-    // }
+    }
 
     setTimeout(() => {
       window.location.reload();

--- a/src/components/Layout/GoogleTranslate.js
+++ b/src/components/Layout/GoogleTranslate.js
@@ -54,7 +54,7 @@ export const GoogleTranslate = () => {
     // FIXME: removeCookie does not appear to work in Safari
     if (!locale || locale === 'auto') {
       removeCookie('googtrans', { path: '/' });
-    } else { 
+    } else {
     */
       setCookie('googtrans', `/auto/${locale}`, { path: '/' })
     //}

--- a/src/components/Layout/GoogleTranslate.js
+++ b/src/components/Layout/GoogleTranslate.js
@@ -50,13 +50,14 @@ export const GoogleTranslate = () => {
     if (locale === previous) { console.log('locale unchanged.');return; }
 
     console.log('Setting locale to: ', locale);
-
+    /*
+    // FIXME: removeCookie does not appear to work in Safari
     if (!locale || locale === 'auto') {
-      // FIXME: removeCookie does not appear to work in Safari
       removeCookie('googtrans', { path: '/' });
-    } else {
+    } else { 
+    */
       setCookie('googtrans', `/auto/${locale}`, { path: '/' })
-    }
+    //}
 
     setTimeout(() => {
       window.location.reload();

--- a/src/components/Layout/Navbar.js
+++ b/src/components/Layout/Navbar.js
@@ -13,7 +13,7 @@ import Grid from "@mui/material/Grid";
 import {DropdownButton} from "../VariablePanel/DropdownButton";
 import {MdHomeFilled} from "react-icons/md";
 import useMediaQuery from "@mui/material/useMediaQuery";
-import {selectLocale, setLocale} from "../../store/slices/sensorDataSlice";
+import {setLocale} from "../../store/slices/sensorDataSlice";
 import {useCookies} from "react-cookie";
 import {NavDropdown} from "./NavDropdown";
 import MenuItem from "@mui/material/MenuItem";

--- a/src/components/Layout/Navbar.js
+++ b/src/components/Layout/Navbar.js
@@ -11,7 +11,7 @@ import {selectPanelState, setPanelState} from '../../store/slices/legacyStoreSli
 import * as SVG from '../../config/svg';
 import Grid from "@mui/material/Grid";
 import {DropdownButton} from "../VariablePanel/DropdownButton";
-import {MdHomeFilled} from "react-icons/md";
+import {MdHomeFilled, MdOutlineTranslate} from "react-icons/md";
 import useMediaQuery from "@mui/material/useMediaQuery";
 import {setLocale} from "../../store/slices/sensorDataSlice";
 import {useCookies} from "react-cookie";
@@ -144,7 +144,7 @@ export default function Nav({
           <Grid container justifyContent={largeScreen ? 'space-between' : 'center'} alignItems={'center'} flexDirection={largeScreen ? 'row' : 'column-reverse'}>
             <Grid size='grow'>
               {(largeScreen || mobileNavOpen) && <Grid spacing={2} container justifyContent={largeScreen ? 'initial' : 'center'} alignItems={'center'}>
-                <DropdownButton style={{ fontSize }} ButtonComponent={LButton} label={getLocaleLabel(cookies['googtrans'])} options={locales} onChange={onLocaleChange} />
+                <DropdownButton style={{ fontSize }} ButtonComponent={LButton} icon={<MdOutlineTranslate />} label={getLocaleLabel(cookies['googtrans'])} options={locales} onChange={onLocaleChange} />
                 <LButton style={{ fontSize }} onClick={() => navigate('/')}><MdHomeFilled /></LButton>
                 <NavDropdown key={'about'} label={'Maps & more'} style={{ fontSize }}>
                   <MenuItem as={LButton} onClick={() => navigate('/map')}>Our Air Map</MenuItem>

--- a/src/components/Layout/Navbar.js
+++ b/src/components/Layout/Navbar.js
@@ -13,10 +13,11 @@ import Grid from "@mui/material/Grid";
 import {DropdownButton} from "../VariablePanel/DropdownButton";
 import {MdHomeFilled} from "react-icons/md";
 import useMediaQuery from "@mui/material/useMediaQuery";
-import {setLocale} from "../../store/slices/sensorDataSlice";
+import {selectLocale, setLocale} from "../../store/slices/sensorDataSlice";
 import {useCookies} from "react-cookie";
 import {NavDropdown} from "./NavDropdown";
 import MenuItem from "@mui/material/MenuItem";
+import {getLocaleLabel, locales} from "../VariablePanel/common";
 
 const NavItems = styled.ul`
   margin-top:.25em;
@@ -130,7 +131,7 @@ export default function Nav({
 
   const onLocaleChange = (locale) => {
     dispatch(setLocale(locale));
-  }
+  };
 
   const lgScreenFontSize = '20px';
   const xsScreenFontSize = '16px'
@@ -143,7 +144,7 @@ export default function Nav({
           <Grid container justifyContent={largeScreen ? 'space-between' : 'center'} alignItems={'center'} flexDirection={largeScreen ? 'row' : 'column-reverse'}>
             <Grid size='grow'>
               {(largeScreen || mobileNavOpen) && <Grid spacing={2} container justifyContent={largeScreen ? 'initial' : 'center'} alignItems={'center'}>
-                <DropdownButton style={{ fontSize }} ButtonComponent={LButton} label={cookies['googtrans'] === '/auto/es' ? 'Español' : 'English'} options={[{label:'English', value:'en'}, {label:'Español',value:'es'}]} onChange={onLocaleChange} />
+                <DropdownButton style={{ fontSize }} ButtonComponent={LButton} label={getLocaleLabel(cookies['googtrans'])} options={locales} onChange={onLocaleChange} />
                 <LButton style={{ fontSize }} onClick={() => navigate('/')}><MdHomeFilled /></LButton>
                 <NavDropdown key={'about'} label={'Maps & more'} style={{ fontSize }}>
                   <MenuItem as={LButton} onClick={() => navigate('/map')}>Our Air Map</MenuItem>

--- a/src/components/Map/DataPanel.js
+++ b/src/components/Map/DataPanel.js
@@ -23,7 +23,7 @@ import {FaGripLines} from "react-icons/fa";
 import {MapLayersPanel} from "../VariablePanel/Panels/MapLayersPanel";
 import {ClickedSensorPanel} from "../VariablePanel/Panels/ClickedSensorPanel";
 import {SelectedAreaPanel} from "../VariablePanel/Panels/SelectedAreaPanel";
-import {LButton, Divider, useSelectorAsState} from "../VariablePanel/common";
+import {LButton, Divider, useSelectorAsState, getLocaleLabel, locales} from "../VariablePanel/common";
 import {ClickedSensorDetailsPanel} from "../VariablePanel/Panels/ClickedSensorDetailsPanel";
 import {ClickedSensorExplain} from "../VariablePanel/Panels/ClickedSensorExplainPanel";
 import {ColorCodingAQPanel} from "../VariablePanel/Panels/ColorCodingAQPanel";
@@ -172,7 +172,7 @@ const DataPanel = ({ mapRef }) => {
     <DataPanelContainer $large={largeScreen} $open={!!panelState.info} id="data-panel">
       <Grid container spacing={2} alignItems={'center'}>
         <Grid size={9}><img src={'/icons/chiair-logo.svg'} alt={'Chicago Air Quality'} width={254} height={41}/></Grid>
-        <Grid><DropdownButton ButtonComponent={LButton} truncate={3} label={cookies['googtrans'] === '/auto/es' ? 'Español' : 'English'} onChange={onLocaleChange}  options={[{label:'English', value:'en'}, {label:'Español',value:'es'}]} /></Grid>
+        <Grid><DropdownButton ButtonComponent={LButton} truncate={3} label={getLocaleLabel(cookies['googtrans'])} onChange={onLocaleChange}  options={locales} /></Grid>
       </Grid>
 
       <Grid container spacing={8} alignItems={'center'}>

--- a/src/components/Pages/Home.js
+++ b/src/components/Pages/Home.js
@@ -286,7 +286,7 @@ export default function Home() {
               </Grid>
               <Grid size={{ xs: 12, md: 6 }}>
                 <HeroContent $largeScreen={largeScreen}>
-                  <HeroTitle $largeScreen={largeScreen}>
+                  <HeroTitle $largeScreen={largeScreen} className={'notranslate'}>
                     Our<HeroTitleAccent>Air</HeroTitleAccent>
                   </HeroTitle>
                   <HeroKicker $largeScreen={largeScreen}>Mapping the Open Air Network</HeroKicker>

--- a/src/components/Pages/Home.js
+++ b/src/components/Pages/Home.js
@@ -27,6 +27,7 @@ const brandColors = {
 const HeroSectionInner = styled.div`
     position: relative;
     padding-bottom: 6.5rem;
+    margin-top: 6rem;
 `;
 const HeroArtwork = styled.div`
     position: absolute;

--- a/src/components/VariablePanel/DropdownButton.js
+++ b/src/components/VariablePanel/DropdownButton.js
@@ -7,7 +7,7 @@ import {LButton} from "./common";
 
 const ITEM_HEIGHT = 48;
 
-export const DropdownButton = ({ className = '', onOpen = () => {}, buttonProps = {}, width, menuStyle, style, onChange, options, label, ButtonComponent, unique = true, sortOptions = true }) => {
+export const DropdownButton = ({ className = '', icon = undefined, onOpen = () => {}, buttonProps = {}, width, menuStyle, style, onChange, options, label, ButtonComponent, unique = true, sortOptions = true }) => {
   // Keep track of our anchor element
   const [anchorEl, setAnchorEl] = useState(null);
   const open = !!anchorEl;
@@ -50,7 +50,7 @@ export const DropdownButton = ({ className = '', onOpen = () => {}, buttonProps 
         style={style}
         {...buttonProps}
       >
-        {label} <FaCaretDown style={{ marginLeft: '2px' }} />
+        {icon ? <span style={{ marginRight: '1rem' }}>{icon}</span> : <></>} {label} <FaCaretDown style={{ marginLeft: '2px' }} />
       </Btn>
       <Menu
           id="basic-menu"

--- a/src/components/VariablePanel/common.js
+++ b/src/components/VariablePanel/common.js
@@ -216,6 +216,6 @@ export const locales = [
 ];
 
 export const getLocaleLabel = (value) => {
-  const stripped = value.replaceAll('/auto/', '');
-  return locales.find(l => stripped === l.value)?.label;
+  const stripped = value?.replaceAll('/auto/', '');
+  return locales?.find(l => stripped === l?.value)?.label;
 };

--- a/src/components/VariablePanel/common.js
+++ b/src/components/VariablePanel/common.js
@@ -207,3 +207,15 @@ export const flyToCenter = (boundaries, name, key, navigate) => {
     }).toString()
   });
 }
+
+export const locales = [
+  {label:'English', value:'en'},
+  {label:'Español', value:'es'},
+  {label:'普通话', value:'zh-CN'},
+  {label:'Polski', value:'pl'}
+];
+
+export const getLocaleLabel = (value) => {
+  const stripped = value.replaceAll('/auto/', '');
+  return locales.find(l => stripped === l.value)?.label;
+};


### PR DESCRIPTION
## Problem
We would like to expand our list of supported languages to include Polish and Mandarin

Fixes #99 

## Approach
* refactor: adjust how these language options are shared/sourced thru different components
* feat: added Polish (`pl`) and Mandarin (`zh-CN`) as language options here

Extra testing for Safari to make sure I didn't reintroduce the bug that we just fixed :pray:

## How to Test
1. Navigate to the homepage
2. Expand the language dropdown at the top-left
    * You should now see 4 options here: English, Español, 普通话, and Polski
3. Choose one of the languages, and wait a few seconds for the page to refresh + translate
    * You should see that after automatic refresh, the page renders in the chosen language
