### PR TITLE
fix: slightly better logic for detecting offline sensors

### DIFF
--- a/src/components/Map/MapSection.js
+++ b/src/components/Map/MapSection.js
@@ -204,6 +204,10 @@ function MapSection({ mapRef, handlePanMap = (viewState) => {}, setViewStateFn =
   const filterValues = useSelector(selectFilterValues);
   const use3d = useSelector(selectUse3d);
 
+  const isSensorOffline = (latest) => {
+    return !latest || latest === "None" || latest === "NaN" || Number.isNaN(latest);
+  }
+
   const bins = pm2_5Ranges.map(r => {
     if (selectedParameter === 'nowcast_aqi') {
       return r.aqi_max;
@@ -305,7 +309,7 @@ function MapSection({ mapRef, handlePanMap = (viewState) => {}, setViewStateFn =
         return [229, 238, 245];
       }
       const latest = data?.find(() => true)?.value;
-      if (latest === null || latest === undefined || latest === "None" || latest === "NaN") {
+      if (isSensorOffline(latest)) {
         //return [79, 143, 197];
         return [200, 200, 200];
       }
@@ -325,7 +329,7 @@ function MapSection({ mapRef, handlePanMap = (viewState) => {}, setViewStateFn =
         return [79, 143, 197];
       }
       const latest = data?.find(() => true)?.value;
-      if (latest === "None" || latest === "NaN" || latest === null || latest === undefined) {
+      if (isSensorOffline(latest)) {
         return [229, 238, 245];
         //return [68, 68, 68];
       }
@@ -370,7 +374,7 @@ function MapSection({ mapRef, handlePanMap = (viewState) => {}, setViewStateFn =
         return [79, 143, 197];
       }
       const latest = data?.find(() => true)?.value;
-      if (!latest || latest === "None" || latest === "NaN") {
+      if (isSensorOffline(latest)) {
         //return [79, 143, 197];
         return [100, 100, 100];
       }
@@ -390,7 +394,7 @@ function MapSection({ mapRef, handlePanMap = (viewState) => {}, setViewStateFn =
         return [229, 238, 245];
       }
       const latest = data?.find(() => true)?.value;
-      if (latest === "None" || latest === "NaN" || latest === null || latest === undefined) {
+      if (isSensorOffline(latest)) {
         //return [229, 238, 245];
         //return [68, 68, 68];
         return [200, 200, 200];
@@ -438,7 +442,7 @@ function MapSection({ mapRef, handlePanMap = (viewState) => {}, setViewStateFn =
         return [79, 143, 197];
       }
       const latest = data?.find(() => true)?.value;
-      if (latest === null || latest === undefined || latest === "None" || latest === "NaN") {
+      if (isSensorOffline(latest)) {
       //return [79, 143, 197];
         return [100, 100, 100];
       }

--- a/src/components/Map/MapSection.js
+++ b/src/components/Map/MapSection.js
@@ -370,7 +370,7 @@ function MapSection({ mapRef, handlePanMap = (viewState) => {}, setViewStateFn =
         return [79, 143, 197];
       }
       const latest = data?.find(() => true)?.value;
-      if (latest === null || latest === undefined || latest === "None" || latest === "NaN") {
+      if (!latest || latest === "None" || latest === "NaN") {
         //return [79, 143, 197];
         return [100, 100, 100];
       }


### PR DESCRIPTION
## Problem
Some older sensors from our dataset have gone away or moved
This is expected, but the map still sometimes shows them as green or purple

We should show sensors in this state as a gray circle instead

Fixes https://github.com/healthyregions/clarity-aq-pipeline/issues/31

## Approach
* fix: adjust color detection to include `0` as an invalid value along with null, None, NaN, etc
   * Assumption: there will always be some a nonzero (e.g. 0.1 or higher) amount of particulate matter in the air
* refactor: extract a method from our current offline sensor logic so that we can be sure we change it consistently when adjusting the colors on the map

## How to Test
1. Navigate to /map
    * You should see that offline sensors once again appear as gray circles

