### PR TITLE
style: design audit 05/29/2026

### DIFF
--- a/src/components/Layout/NavDropdown.js
+++ b/src/components/Layout/NavDropdown.js
@@ -3,7 +3,7 @@ import {LButton} from "../VariablePanel/common";
 import {useState} from "react";
 import {FaCaretDown} from "react-icons/fa";
 
-export const NavDropdown = ({ key = 'basic', label, style, children = <></> }) => {
+export const NavDropdown = ({ keyName = 'basic', label, style, children = <></> }) => {
   const [anchorEl, setAnchorEl] = useState(null);
   const open = Boolean(anchorEl);
   const handleClick = (event) => {
@@ -16,8 +16,8 @@ export const NavDropdown = ({ key = 'basic', label, style, children = <></> }) =
   return (
     <>
       <LButton
-        id={`${key}-button`}
-        aria-controls={open ? `${key}-menu` : undefined}
+        id={`${keyName}-button`}
+        aria-controls={open ? `${keyName}-menu` : undefined}
         aria-haspopup="true"
         style={style}
         aria-expanded={open ? 'true' : undefined}
@@ -26,14 +26,14 @@ export const NavDropdown = ({ key = 'basic', label, style, children = <></> }) =
         {label} <FaCaretDown style={{ marginLeft: '2px' }} />
       </LButton>
       <Menu
-        id={`${key}-menu`}
+        id={`${keyName}-menu`}
         anchorEl={anchorEl}
         open={open}
         style={style}
         onClose={handleClose}
         slotProps={{
           list: {
-            'aria-labelledby': `${key}-button`,
+            'aria-labelledby': `${keyName}-button`,
           },
         }}
       >

--- a/src/components/Layout/Navbar.js
+++ b/src/components/Layout/Navbar.js
@@ -145,11 +145,11 @@ export default function Nav({
               {(largeScreen || mobileNavOpen) && <Grid spacing={2} container justifyContent={largeScreen ? 'initial' : 'center'} alignItems={'center'}>
                 <DropdownButton style={{ fontSize }} ButtonComponent={LButton} label={cookies['googtrans'] === '/auto/es' ? 'Español' : 'English'} options={[{label:'English', value:'en'}, {label:'Español',value:'es'}]} onChange={onLocaleChange} />
                 <LButton style={{ fontSize }} onClick={() => navigate('/')}><MdHomeFilled /></LButton>
-                <NavDropdown key={'about'} label={'Maps & more'} style={{ fontSize }}>
+                <NavDropdown keyName={'maps'} label={'Maps & more'} style={{ fontSize }}>
                   <MenuItem as={LButton} onClick={() => navigate('/map')}>Our Air Map</MenuItem>
                   <MenuItem as={LButton} onClick={() => navigate('/resources')}>All Resources</MenuItem>
                 </NavDropdown>
-                <NavDropdown key={'about'} label={'About'} style={{ fontSize }}>
+                <NavDropdown keyName={'about'} label={'About'} style={{ fontSize }}>
                   <MenuItem as={LButton} onClick={() => navigate('/team')}>Team</MenuItem>
                   <MenuItem as={LButton} onClick={() => navigate('/about')}>Info & FAQ</MenuItem>
                 </NavDropdown>

--- a/src/components/Map/Geocoder.js
+++ b/src/components/Map/Geocoder.js
@@ -137,8 +137,8 @@ export const Geocoder = ({ showSelectedAreas = true, onDropdownChange, placehold
                           fontWeight: part.highlight ? 700 : 400,
                         }}
                       >
-                {part.text}
-              </span>
+                        {part.text}
+                      </span>
                     ))}
                   </div>
                 </li>

--- a/src/components/Map/Geocoder.js
+++ b/src/components/Map/Geocoder.js
@@ -156,7 +156,7 @@ export const Geocoder = ({ showSelectedAreas = true, onDropdownChange, placehold
                     startAdornment:
                       <FaSearch style={{color: 'rgba(0, 88, 153, 1)', marginLeft:'1.25rem', marginRight: '0.5rem' }}></FaSearch>,
                     endAdornment:
-                      searchState?.value && <FaTimes style={{ color: 'rgba(0, 88, 153, 1)', cursor: 'pointer', marginLeft: '0.675rem', marginRight: '0.875rem' }}
+                      searchState?.value && <FaTimes style={{ color: 'rgba(0, 88, 153, 1)', cursor: 'pointer', marginLeft: '8px', marginRight: '20px' }}
                                                      onClick={() => setSearchState({ value: '' })} />
 
                   },

--- a/src/components/Pages/About.js
+++ b/src/components/Pages/About.js
@@ -256,7 +256,7 @@ export default function About() {
            </Grid> */}
              <Grid container spacing={3} textAlign={'right'} marginTop={'2rem'}>
                <AboutBodyText size={12}>
-                <b>Our Air</b> is a Chicago mapping application that serves as a vital bridge between air quality data, research exploration, and community advocacy,
+                <b className={'notranslate'}>Our Air</b> is a Chicago mapping application that serves as a vital bridge between air quality data, research exploration, and community advocacy,
                  making city-wide metrics legible for all. We build on the largest sensor network in the country with community and
                  cross-sector collaborations to ensure the data is easily accessible, in context, and ready
                  for action. We will continue to refine and add to the dashboard with improvements and more resources over time.
@@ -320,7 +320,7 @@ export default function About() {
                </Grid>
                <Grid size={12} marginTop={'1rem'} style={{ fontFamily: 'Space Grotesk', fontSize: '18px', color: '##444444' }}>
               <a href="https://publichealth.uic.edu/profiles/serap-erdal/" style={{ textDecoration: 'none', color: '#005899', fontWeight: 700 }}>Dr. Serap Erdal </a>
-               from UIC led the scientific process of grid development, sensor placement, and quality assurance protocol development, with support from the ComEd Hyperlocal Air 
+               from UIC led the scientific process of grid development, sensor placement, and quality assurance protocol development, with support from the ComEd Hyperlocal Air
                Quality Assessment by RHP Risk Management/ComEd/Exelon LLC, and Congressional Earmark Grant/National Institute of Standards and Technology (#60NANB23D206).
                 </Grid>
              </Grid>

--- a/src/components/Pages/Home.js
+++ b/src/components/Pages/Home.js
@@ -144,7 +144,7 @@ const HeroButton = styled(Button)`
     padding: 0 1.5rem;
     z-index: 55;
 `;
-const SearchBand = styled.section`
+const SearchBand = styled.div`
     position: relative;
     z-index: 1;
     width: 100%;
@@ -180,7 +180,6 @@ const SearchBandDecorItem = styled.img`
     z-index: 10;
     left: ${({ $x }) => $x};
     top: ${({ $y }) => $y};
-    bottom: ${({ $bottom }) => $bottom};
     transform: ${({ $mirror }) => $mirror ? 'scaleX(-1)' : 'none'};
 `;
 const SearchBandChevron = styled(FaChevronDown)`
@@ -233,10 +232,10 @@ const resources = [
 
 const headerDecorItems = [
   { src: '/img/header/header1.svg', offsetFromHeader6: 19.44, y: '6.5rem' },
-  { src: '/img/header/header2.svg', offsetFromHeader6: 19.44, bottom: '10.19rem' },
+  { src: '/img/header/header2.svg', offsetFromHeader6: 19.44, y: '12rem' },
   { src: '/img/header/header3.svg', offsetFromHeader6: 12.87, y: '9.25rem' },
   { src: '/img/header/header4.svg', offsetFromHeader6: 6.5, y: '6.5rem' },
-  { src: '/img/header/header5.svg', offsetFromHeader6: 6.5, bottom: '10.19rem' },
+  { src: '/img/header/header5.svg', offsetFromHeader6: 6.5, y: '12rem' },
   { src: '/img/header/header6.svg', offsetFromHeader6: 0, y: '9.12rem' },
 ];
 
@@ -322,7 +321,6 @@ export default function Home() {
                 alt={''}
                 $x={`calc(50% - ${searchBandHeader6LeftAnchor + item.offsetFromHeader6}rem)`}
                 $y={item.y}
-                $bottom={item.bottom}
               />
             ))}
           </SearchBandDecor>
@@ -334,7 +332,6 @@ export default function Home() {
                 alt={''}
                 $x={`calc(50% + ${searchBandHeader6RightAnchor + item.offsetFromHeader6}rem)`}
                 $y={item.y}
-                $bottom={item.bottom}
                 $mirror
               />
             ))}

--- a/src/components/Pages/Home.js
+++ b/src/components/Pages/Home.js
@@ -83,11 +83,11 @@ const HeroContent = styled.div`
     display: flex;
     flex-direction: column;
     align-items: ${({ $largeScreen }) => $largeScreen ? 'flex-end' : 'center'};
-    justify-content: center;
+    justify-content: end;
     text-align: ${({ $largeScreen }) => $largeScreen ? 'right' : 'center'};
     width: 100%;
-    max-width: ${({ $largeScreen }) => $largeScreen ? '34rem' : '100%'};
-    margin-left: auto;
+    //max-width: ${({ $largeScreen }) => $largeScreen ? '34rem' : '100%'};
+    //margin-left: auto;
 `;
 const HeroTitle = styled.h1`
     font-family: Lexend,sans-serif;
@@ -105,6 +105,7 @@ const HeroTitleAccent = styled.span`
 `;
 const HeroKicker = styled.div`
     margin-top: 0.75rem;
+    //text-wrap: nowrap;
     font-family: Lexend,sans-serif;
     color: ${brandColors.chiLightBlue};
     font-size: ${({ $largeScreen }) => $largeScreen ? '2rem' : '1.5rem'};
@@ -113,6 +114,7 @@ const HeroKicker = styled.div`
 `;
 const HeroKickerAccent = styled.div`
     font-family: Lexend,sans-serif;
+    //text-wrap: nowrap;
     color: ${brandColors.chiRed};
     font-size: ${({ $largeScreen }) => $largeScreen ? '2rem' : '1.5rem'};
     font-weight: 700;
@@ -274,8 +276,8 @@ export default function Home() {
       <WhiteBackground $largeScreen={largeScreen} style={{ marginBottom: 0, marginTop: '4rem' }}>
         <ContentContainer>
           <HeroSectionInner>
-            <Grid container spacing={largeScreen ? 4 : 0} alignItems={'center'}>
-              <Grid size={{ xs: 12, md: 6 }}>
+            <Grid container spacing={largeScreen ? 4 : 0} justifyContent={'end'}>
+              <Grid size={{ xs: 12, md: 1 }}>
                 <HeroArtwork $largeScreen={largeScreen} $xlScreen={xlScreen}>
                   <HeroLight src={'/img/header/light.svg'} alt={''} $largeScreen={largeScreen} />
                   <HeroGroup src={'/img/header/group.svg'} alt={''} $largeScreen={largeScreen} />
@@ -284,7 +286,7 @@ export default function Home() {
                   <HeroSquirrel src={'/img/header/squirrel.svg'} alt={''} $largeScreen={largeScreen} />
                 </HeroArtwork>
               </Grid>
-              <Grid size={{ xs: 12, md: 6 }}>
+              <Grid size={{ xs: 12, md: 11 }}>
                 <HeroContent $largeScreen={largeScreen}>
                   <HeroTitle $largeScreen={largeScreen}>
                     Our<HeroTitleAccent>Air</HeroTitleAccent>

--- a/src/components/Pages/Home.js
+++ b/src/components/Pages/Home.js
@@ -148,9 +148,9 @@ const SearchBand = styled.section`
     position: relative;
     z-index: 1;
     width: 100%;
-    background: url('/img/header/home-page-header-background.svg') center top / cover no-repeat;
+    //background: url('/img/header/home-page-header-background.svg') center top / cover no-repeat;
     padding: ${({ $largeScreen }) => $largeScreen ? '4.31rem 0 3.03rem' : '3rem 0 2.5rem'};
-    overflow: hidden;
+    //overflow: hidden;
 `;
 const SearchBandInner = styled.div`
     position: relative;
@@ -163,16 +163,21 @@ const SearchBandDecor = styled.div`
     position: absolute;
     top: 0;
     bottom: 0;
-    left: 0;
+    left: -23px;
     right: 0;
     pointer-events: none;
-    opacity: ${({ $largeScreen }) => $largeScreen ? 1 : 0};
     display: ${({ $largeScreen }) => $largeScreen ? 'block' : 'none'};
+    background: linear-gradient(
+      ${({ $direction }) => $direction || 'to bottom'},
+      ${({ $startColor }) => $startColor || 'rgba(209, 237, 251, 1)'},
+      ${({ $endColor }) => $endColor || 'rgba(255, 255, 255, 1)'}
+    );
 `;
 const SearchBandDecorItem = styled.img`
     position: absolute;
     width: 1.5rem;
     height: 1.5rem;
+    z-index: 10;
     left: ${({ $x }) => $x};
     top: ${({ $y }) => $y};
     bottom: ${({ $bottom }) => $bottom};

--- a/src/components/Pages/Team.js
+++ b/src/components/Pages/Team.js
@@ -305,7 +305,7 @@ export default function Team() {
 
           <Grid container spacing={8} marginBottom={8} alignItems={'start'} rowSpacing={4}>
             {coreteam?.map((contributor, index) =>
-              <Grid key={'leadership-' + index} size={{ xs: 12, md: 3 }} justifyItems={'center'}>
+              <Grid key={'coreteam-' + index} size={{ xs: 12, md: 3 }} justifyItems={'center'}>
                 <Grid container spacing={3} alignItems={'center'} justifyContent={'center'}>
                   <img src={contributor?.photo} alt={''} />
                   <ContributorLabel className={'notranslate'} $largeScreen={largeScreen}>{contributor?.name}</ContributorLabel>
@@ -328,7 +328,7 @@ export default function Team() {
 
           <Grid container spacing={8} marginTop={9} marginBottom={8} alignItems={'start'} rowSpacing={4}>
             {students?.map((contributor, index) =>
-              <Grid key={'leadership-' + index} size={{ xs: 12, md: 3 }} justifyItems={'center'}>
+              <Grid key={'students-' + index} size={{ xs: 12, md: 3 }} justifyItems={'center'}>
                 <Grid container spacing={3} alignItems={'center'} justifyContent={'center'}>
                   <img src={contributor?.photo} alt={''} />
                   <ContributorLabel className={'notranslate'} $largeScreen={largeScreen}>{contributor?.name}</ContributorLabel>
@@ -356,7 +356,7 @@ export default function Team() {
       </CategorySection>
         <Grid container spacing={8} marginBottom={8} alignItems={'start'} rowSpacing={4}>
           {communityorgs?.map((contributor, index) =>
-            <Grid key={'community-' + index} size={{ xs: 12, md: 3 }}
+            <Grid key={'communityorgs-' + index} size={{ xs: 12, md: 3 }}
               onClick={() => contributor?.url && window.open(contributor.url, '_blank', 'noopener,noreferrer')}
               style={{ cursor: 'pointer' }} justifyItems={'center'}>
               <Grid container spacing={3} alignItems={'center'} justifyContent={'center'}>
@@ -378,7 +378,7 @@ export default function Team() {
         </CategorySection>
           <Grid container spacing={8} marginBottom={8} alignItems={'start'} rowSpacing={4}>
             {communityindividual?.map((contributor, index) =>
-              <Grid key={'leadership-' + index} size={{ xs: 12, md: 3 }} justifyItems={'center'}>
+              <Grid key={'communityindividual-' + index} size={{ xs: 12, md: 3 }} justifyItems={'center'}>
                 <Grid container spacing={3} alignItems={'center'} justifyContent={'center'}>
                   <ContributorLabel className={'notranslate'} $largeScreen={largeScreen}>{contributor?.name}</ContributorLabel>
                   <ContributorDescription>{contributor?.description}</ContributorDescription>

--- a/src/components/Pages/Team.js
+++ b/src/components/Pages/Team.js
@@ -263,7 +263,7 @@ export default function Team() {
           </Grid>
           <Grid container spacing={3} textAlign={'right'} marginTop={'2rem'}>
             <TeamBodyText size={12}>
-              <b>Our Air</b> is a collective effort driven by a shared commitment to data transparency and public health. This page honors the diverse group of individuals from academic institutions to community partners across Chicago, who contributed their technical insights and lived experiences to architect a platform that empowers people to understand the air they breathe.
+              <b className={'notranslate'}>Our Air</b> is a collective effort driven by a shared commitment to data transparency and public health. This page honors the diverse group of individuals from academic institutions to community partners across Chicago, who contributed their technical insights and lived experiences to architect a platform that empowers people to understand the air they breathe.
             </TeamBodyText>
           </Grid>
         </ContentContainer>

--- a/src/components/Pages/Team.js
+++ b/src/components/Pages/Team.js
@@ -292,7 +292,7 @@ export default function Team() {
               <Grid key={'leadership-' + index} size={{ xs: 12, md: 3 }} justifyItems={'center'}>
                 <Grid container spacing={3} alignItems={'center'} justifyContent={'center'}>
                   <img src={contributor?.photo} alt={''} />
-                  <ContributorLabel $largeScreen={largeScreen}>{contributor?.name}</ContributorLabel>
+                  <ContributorLabel className={'notranslate'} $largeScreen={largeScreen}>{contributor?.name}</ContributorLabel>
                   <ContributorDescription>{contributor?.description}</ContributorDescription>
                 </Grid>
               </Grid>
@@ -308,7 +308,7 @@ export default function Team() {
               <Grid key={'leadership-' + index} size={{ xs: 12, md: 3 }} justifyItems={'center'}>
                 <Grid container spacing={3} alignItems={'center'} justifyContent={'center'}>
                   <img src={contributor?.photo} alt={''} />
-                  <ContributorLabel $largeScreen={largeScreen}>{contributor?.name}</ContributorLabel>
+                  <ContributorLabel className={'notranslate'} $largeScreen={largeScreen}>{contributor?.name}</ContributorLabel>
                   <ContributorDescription>{contributor?.description}</ContributorDescription>
                 </Grid>
               </Grid>
@@ -317,7 +317,7 @@ export default function Team() {
 
           <Grid container spacing={3} textAlign={'right'} marginTop={'2rem'} marginBottom={8}>
             <TeamBodyText>
-              We are additionally grateful to <b>Mallikarjun Bhusnoor</b> and <b>Pengyin Shan</b> at UIUC for their technical support. 
+              We are additionally grateful to <b>Mallikarjun Bhusnoor</b> and <b>Pengyin Shan</b> at UIUC for their technical support.
             </TeamBodyText>
           </Grid>
 
@@ -331,7 +331,7 @@ export default function Team() {
               <Grid key={'leadership-' + index} size={{ xs: 12, md: 3 }} justifyItems={'center'}>
                 <Grid container spacing={3} alignItems={'center'} justifyContent={'center'}>
                   <img src={contributor?.photo} alt={''} />
-                  <ContributorLabel $largeScreen={largeScreen}>{contributor?.name}</ContributorLabel>
+                  <ContributorLabel className={'notranslate'} $largeScreen={largeScreen}>{contributor?.name}</ContributorLabel>
                   <ContributorDescription>{contributor?.description}</ContributorDescription>
                 </Grid>
               </Grid>
@@ -361,7 +361,7 @@ export default function Team() {
               style={{ cursor: 'pointer' }} justifyItems={'center'}>
               <Grid container spacing={3} alignItems={'center'} justifyContent={'center'}>
                 <img src={contributor?.photo} style={{ minHeight: '100px', maxHeight: '100px' }} alt={''} />
-                <ContributorLabel $largeScreen={largeScreen}>{contributor?.name} <ResourceLinkIcon /></ContributorLabel>
+                <ContributorLabel className={'notranslate'} $largeScreen={largeScreen}>{contributor?.name} <ResourceLinkIcon /></ContributorLabel>
                 <ContributorDescription>{contributor?.description}</ContributorDescription>
               </Grid>
             </Grid>
@@ -380,7 +380,7 @@ export default function Team() {
             {communityindividual?.map((contributor, index) =>
               <Grid key={'leadership-' + index} size={{ xs: 12, md: 3 }} justifyItems={'center'}>
                 <Grid container spacing={3} alignItems={'center'} justifyContent={'center'}>
-                  <ContributorLabel $largeScreen={largeScreen}>{contributor?.name}</ContributorLabel>
+                  <ContributorLabel className={'notranslate'} $largeScreen={largeScreen}>{contributor?.name}</ContributorLabel>
                   <ContributorDescription>{contributor?.description}</ContributorDescription>
                 </Grid>
               </Grid>

--- a/src/components/VariablePanel/Panels/AreaSelectionDropdowns.js
+++ b/src/components/VariablePanel/Panels/AreaSelectionDropdowns.js
@@ -60,26 +60,33 @@ const HomeDropdownSearchInput = styled(InputBase)`
 const HomeDropdownOptions = styled(Box)`
   max-height: 23rem;
   overflow-y: auto;
-  padding: 1rem 1.25rem 1.25rem;
+  padding: 0.75rem 1.25rem 1.25rem;
 
   &::-webkit-scrollbar {
-    width: 6px;
+    width: 25px;
   }
 
   &::-webkit-scrollbar-thumb {
     background: #8DBBDD;
-    border-radius: 999px;
+    border-radius: 2px;
+      
+    /* Use a transparent border to create the offset */
+    border-left: 2px solid transparent;
+    border-right: 20px solid transparent;
+    background-clip: content-box;
   }
 
   &::-webkit-scrollbar-track {
     background: transparent;
+    margin-top: 20px;
+    margin-bottom: 20px;
   }
 `;
 
 const HomeDropdownOption = styled.button`
   display: block;
   width: 100%;
-  padding: 0.625rem 0;
+  padding: 0.325rem 0;
   border: 0;
   background: transparent;
   text-align: left;

--- a/src/components/VariablePanel/Panels/AreaSelectionDropdowns.js
+++ b/src/components/VariablePanel/Panels/AreaSelectionDropdowns.js
@@ -9,8 +9,6 @@ import {
 import {useDispatch, useSelector} from "react-redux";
 import {flyToCenter, getBoundaries, LButton, LLabel, useSelectorAsState} from "../common";
 import {useNavigate} from "react-router-dom";
-import Autocomplete from "@mui/material/Autocomplete";
-import TextField from "@mui/material/TextField";
 import {useCallback, useMemo, useState} from "react";
 import {selectMapParams, setMapParams} from "../../../store/slices/legacyStoreSlice";
 import parse from "autosuggest-highlight/parse";
@@ -18,19 +16,22 @@ import match from "autosuggest-highlight/match";
 import Box from "@mui/material/Box";
 import InputBase from "@mui/material/InputBase";
 import useMediaQuery from "@mui/material/useMediaQuery";
+import ClickAwayListener from "@mui/material/ClickAwayListener";
 
 const HomeDropdownCard = styled.div`
   width: 16rem;
   max-width: 45rem;
   margin: 0 auto;
+  z-index: 10;
   border-radius: 0.75rem;
   border: 1px solid #005899;
   background: #FFF;
   box-shadow: 2px 2px 4px 0 rgba(30, 30, 30, 0.05);
   //overflow: hidden;
-  position: absolute;
 
-  left: ${({ $largeScreen }) => $largeScreen ? '38%' : '14%'}
+  position: ${({ $largeScreen }) => $largeScreen ? 'absolute' : 'relative'};
+  left: 0;
+  right: 0;
 `;
 
 const HomeDropdownSearchRow = styled.div`
@@ -181,7 +182,11 @@ export const AreaSelectionDropdowns = ({ showSelectedAreas = true, onChange, siz
     if (type === 'ward') {
       return `Ward ${value}`;
     } else if (type === 'community') {
-      return value[0]?.toUpperCase() + value.substring(1)?.toLowerCase()
+      // capitalize each word
+      const words = value?.split(' ');
+      return words?.map(word => {
+        return word[0]?.toUpperCase() + word.substring(1)?.toLowerCase();
+      })?.join(' ');
     }
     return value;
   }
@@ -213,8 +218,8 @@ export const AreaSelectionDropdowns = ({ showSelectedAreas = true, onChange, siz
 
   return(
     <>
-      {(noSelection || !showSelectedAreas) && <Grid style={{ position: 'relative' }} container width={'100%'} justifyContent={isHomeVariant ? 'center' : 'space-around'} alignItems={'center'} columnGap={isHomeVariant ? 2 : 0} rowGap={isHomeVariant ? 1 : 0}>
-        {[ 'community', 'zip', 'ward' ]?.map((key) => <Grid size key={key}>
+      {(noSelection || !showSelectedAreas) && <Grid container fullWidth justifyContent={'center'} alignItems={'center'} columnGap={isHomeVariant ? 2 : 0} rowGap={isHomeVariant ? 1 : 0} direction={isHomeVariant ? 'column' : 'row'}>
+        {[ 'community', 'zip', 'ward' ]?.map((key) => <Grid size={12} key={key} textAlign={'center'}>
           <LButton
             id={`basic-button-${key}`}
             size={'small'}
@@ -234,76 +239,43 @@ export const AreaSelectionDropdowns = ({ showSelectedAreas = true, onChange, siz
           >
             {prettyTypeName(key)} <FaCaretDown style={{ marginLeft: '2px' }} />
           </LButton>
+
+          {type === key && <>
+            <ClickAwayListener onClickAway={handleClose}>
+              <HomeDropdownCard $largeScreen={largeScreen}>
+                <HomeDropdownSearchRow>
+                  <FaSearch style={{ color: '#005899', fontSize: '0.75rem' }} />
+                  <HomeDropdownSearchInput
+                    autoFocus
+                    value={searchTerm}
+                    onChange={(e) => setSearchTerm(e.target.value)}
+                    placeholder={`Search`}
+                  />
+                  <LButton variant={'text'} size={'small'} onClick={handleClose} style={{ minWidth: 0, padding: 0 }}>
+                    <FaTimes style={{ color: '#005899', fontSize: '0.75rem' }} />
+                  </LButton>
+                </HomeDropdownSearchRow>
+                <HomeDropdownDivider />
+                <HomeDropdownOptions>
+                  {filteredOptions.length > 0 ? filteredOptions.map((option) => {
+                    const matches = match(option, searchTerm, { insideWords: true });
+                    const parts = parse(option, matches);
+
+                    return (
+                      <HomeDropdownOption key={option} type="button" onClick={() => handleChange(unformat(option, type), type)}>
+                        {parts.map((part, index) => (part.highlight ? (
+                          <HomeDropdownHighlight key={index}>{part.text}</HomeDropdownHighlight>
+                        ) : (
+                          <span>{part.text}</span>
+                        )))}
+                      </HomeDropdownOption>
+                    );
+                  }) : <HomeDropdownEmpty>No options</HomeDropdownEmpty>}
+                </HomeDropdownOptions>
+              </HomeDropdownCard>
+            </ClickAwayListener>
+          </>}
         </Grid>)}
-
-        {type && isHomeVariant && <Grid size={12} margin={'0 auto'} padding={0} alignItems={'center'}>
-          <HomeDropdownCard $largeScreen={largeScreen}>
-            <HomeDropdownSearchRow>
-              <FaSearch style={{ color: '#005899', fontSize: '0.75rem' }} />
-              <HomeDropdownSearchInput
-                autoFocus
-                value={searchTerm}
-                onChange={(e) => setSearchTerm(e.target.value)}
-                placeholder={`Search`}
-              />
-              <LButton variant={'text'} size={'small'} onClick={handleClose} style={{ minWidth: 0, padding: 0 }}>
-                <FaTimes style={{ color: '#005899', fontSize: '0.75rem' }} />
-              </LButton>
-            </HomeDropdownSearchRow>
-            <HomeDropdownDivider />
-            <HomeDropdownOptions>
-              {filteredOptions.length > 0 ? filteredOptions.map((option) => {
-                const matches = match(option, searchTerm, { insideWords: true });
-                const parts = parse(option, matches);
-
-                return (
-                  <HomeDropdownOption key={option} type="button" onClick={() => handleChange(unformat(option, type), type)}>
-                    {parts.map((part, index) => (part.highlight ? (
-                      <HomeDropdownHighlight key={index}>{part.text}</HomeDropdownHighlight>
-                    ) : (
-                      <span>{part.text}</span>
-                    )))}
-                  </HomeDropdownOption>
-                );
-              }) : <HomeDropdownEmpty>No options</HomeDropdownEmpty>}
-            </HomeDropdownOptions>
-          </HomeDropdownCard>
-        </Grid>}
-
-        {type && !isHomeVariant && <Grid style={{ position: 'absolute', top: '32px' }} size={12} margin={'0 1rem'} padding={0} alignItems={'center'}>
-          <Autocomplete
-            options={filteredOptions}
-            openOnFocus
-            onBlur={handleClose}
-            autoComplete
-            onChange={(e, s) => handleChange(unformat(s, type), type)}
-            clearOnEscape
-            fullWidth
-            clearIcon={undefined}
-            popupIcon={null}
-            noOptionsText={'No options'}
-            slotProps={{
-              listbox: {
-                sx: { fontFamily: 'Lexend' }
-              }
-            }}
-            renderInput={params => (
-              <TextField
-                {...params}
-                margin={'none'}
-                variant={'outlined'}
-                style={{ height: '1.9rem' }}
-                autoFocus={true}
-                InputProps={{
-                  ...params.InputProps,
-                  startAdornment: (<></>)
-                }}
-                placeholder={`Search`}
-                fullWidth
-              />
-            )}
-          />
-        </Grid>}
       </Grid>}
 
       {showSelectedAreas && (!noSelection || hasSelection) && <Grid container width={'100%'} spacing={0} margin={'0.3rem'} alignItems={'center'} display={'flex'} flexDirection={"row"} justifyContent={'space-between'} fontFamily={'Lexend'}>

--- a/src/components/VariablePanel/Panels/AreaSelectionDropdowns.js
+++ b/src/components/VariablePanel/Panels/AreaSelectionDropdowns.js
@@ -17,6 +17,7 @@ import parse from "autosuggest-highlight/parse";
 import match from "autosuggest-highlight/match";
 import Box from "@mui/material/Box";
 import InputBase from "@mui/material/InputBase";
+import useMediaQuery from "@mui/material/useMediaQuery";
 
 const HomeDropdownCard = styled.div`
   width: 16rem;
@@ -26,7 +27,10 @@ const HomeDropdownCard = styled.div`
   border: 1px solid #005899;
   background: #FFF;
   box-shadow: 2px 2px 4px 0 rgba(30, 30, 30, 0.05);
-  overflow: hidden;
+  //overflow: hidden;
+  position: absolute;
+
+  left: ${({ $largeScreen }) => $largeScreen ? '38%' : '14%'}
 `;
 
 const HomeDropdownSearchRow = styled.div`
@@ -116,6 +120,7 @@ const HomeDropdownEmpty = styled.div`
 export const AreaSelectionDropdowns = ({ showSelectedAreas = true, onChange, size, variant = 'default' }) => {
   const dispatch = useDispatch();
   const navigate = useNavigate();
+  const largeScreen = useMediaQuery('(min-width: 600px)');
   const mapParams = useSelector(selectMapParams);
 
   // Keep track of our anchor element
@@ -232,17 +237,17 @@ export const AreaSelectionDropdowns = ({ showSelectedAreas = true, onChange, siz
         </Grid>)}
 
         {type && isHomeVariant && <Grid size={12} margin={'0 auto'} padding={0} alignItems={'center'}>
-          <HomeDropdownCard>
+          <HomeDropdownCard $largeScreen={largeScreen}>
             <HomeDropdownSearchRow>
-              <FaSearch style={{ color: '#005899', fontSize: '1.5rem' }} />
+              <FaSearch style={{ color: '#005899', fontSize: '0.75rem' }} />
               <HomeDropdownSearchInput
                 autoFocus
                 value={searchTerm}
                 onChange={(e) => setSearchTerm(e.target.value)}
-                placeholder={`Type ${prettyTypeName(type).toLowerCase()} here...`}
+                placeholder={`Search`}
               />
               <LButton variant={'text'} size={'small'} onClick={handleClose} style={{ minWidth: 0, padding: 0 }}>
-                <FaTimes style={{ color: '#005899', fontSize: '1.5rem' }} />
+                <FaTimes style={{ color: '#005899', fontSize: '0.75rem' }} />
               </LButton>
             </HomeDropdownSearchRow>
             <HomeDropdownDivider />
@@ -293,7 +298,7 @@ export const AreaSelectionDropdowns = ({ showSelectedAreas = true, onChange, siz
                   ...params.InputProps,
                   startAdornment: (<></>)
                 }}
-                placeholder={`Search ${prettyTypeName(type)} here...`}
+                placeholder={`Search`}
                 fullWidth
               />
             )}

--- a/src/components/VariablePanel/SectionHeader.js
+++ b/src/components/VariablePanel/SectionHeader.js
@@ -43,7 +43,7 @@ export const SectionHeader = ({ style = {}, buttonIcon = <></>, buttonText = '',
         <ChiBlackText spacing={0} style={{ fontSize: largeScreen ? '32px': '18px', fontWeight: 400, textAlign: 'right' }}>
           <Grid container spacing={2} alignItems={'center'} justifyContent={'right'}>
             <Grid alignItems={'right'} size={{ xs: 10 }}>
-              {topRowText} <div style={{ fontWeight:700 }}>{bottomRowTextBlack} <ChiRedText>{bottomRowTextRed}</ChiRedText></div>
+              {topRowText} <div style={{ fontWeight:700 }}>{bottomRowTextBlack+' '} <ChiRedText>{bottomRowTextRed}</ChiRedText></div>
             </Grid>
             <Grid size={{ xs: 2 }}>
               <SectionIcon width={largeScreen ? 100 : 42} src={imgSrc} alt={imgAlt} />


### PR DESCRIPTION
## Problem
Design discussion from 5/29/2026 yielded some small action items that need to be addressed

Fixes #110 

## Approach
- [x] fix: Homepage Grid - language dropdown was blocked by image, adjust Grid dimensions to prevent wrapping
- [x] Discussed language translation options - no actions taken here at this time (optional actions below)
- [x] Adjust margin on Geocoder endAdornment icon -> `8px` left, `20px` right to match startAdornment
- [x] adjust homepage Geocoder behavior change flex-direction (stack instead of row)
- [x] Desktop: floating dropdown behavior (match DataPanel styling)
<img width="356" height="212" alt="Image" src="https://github.com/user-attachments/assets/1bc79747-5a9d-49cf-a21d-b6374d725ace" />

- [x] Mobile: Accordion-ish behavior
<img width="203" height="261" alt="Image" src="https://github.com/user-attachments/assets/7841e694-4d0e-4dc6-93eb-7e7fb4307860" />

- [x] Styling / margin for scroll bar in AreaSelectionDropdowns
- [x] ~~Increase width of AreaSelectionsDropdown?~~ Shubham will think about it give correct size if this needs to be fixed
- [x] When user clicks outside or on dropdown button again, close the panel - this might involve tricky timing to avoid double-close, etc
- [x] Move SearchBandDecor panel slightly to the left
- [x] Adjust SearchBandDecorItems to have higher z-index
- [x] Adjust background of SearchBand to be CSS gradient instead of background image
- [x] Adjust opacity of icons / search band to make sure they appear as in the designs
- [x] Change helper/placeholder text from AreaSelectionsDropdown to "Search"
- [x] consistent styling between DataPanel & Homepage for AreaSelectionsDropdown - startAdornment/search icon, etc
- [x] DataPanel AreaSelectionDropdowns - ensure proper capitalization of multi-word selections for "Community"
- [x] shrink startAdornment/endAdornment for  AreaSelectionsDropdown search function

## How to Test
Review the above points, ensure that new style is appealing and desirable