### PR TITLE
[WIP] feat: show historical data on the map

### DIFF
--- a/src/components/Map/MapSection.js
+++ b/src/components/Map/MapSection.js
@@ -35,7 +35,7 @@ import {
 import MapMarkerPopup from "./MapMarkerPopup";
 import {
   selectClickedSensor, selectSelectedAreas,
-  selectSelectedSensors,
+  selectSelectedSensors, selectSelectedTimeIndex,
   selectSensorGeojsonData, selectSensorParameter,
   setClickedSensor
 } from "../../store/slices/sensorDataSlice";
@@ -186,6 +186,7 @@ const NavInlineButton = styled.button`
 
 function MapSection({ mapRef, handlePanMap = (viewState) => {}, setViewStateFn = () => {}, bounds, geoids = [], showSearch = true, showCustom = false }) {
   const dispatch = useDispatch();
+  const selectedTimeIndex = useSelector(selectSelectedTimeIndex);
 
   const [searchParams, setSearchParams] = useSearchParams();
   const lon = searchParams.get('lon');
@@ -308,7 +309,7 @@ function MapSection({ mapRef, handlePanMap = (viewState) => {}, setViewStateFn =
       if (!data?.length) {
         return [229, 238, 245];
       }
-      const latest = data?.find(() => true)?.value;
+      const latest = data?.[selectedTimeIndex]?.value;
       if (isSensorOffline(latest)) {
         //return [79, 143, 197];
         return [200, 200, 200];
@@ -319,7 +320,7 @@ function MapSection({ mapRef, handlePanMap = (viewState) => {}, setViewStateFn =
       }
       return scaleColor(latest, bins, pm2_5Ranges.map(r => r.colorComponents));
     },
-    opacity: selectedSensors?.length > 0 ? 0.15 : .85,
+    opacity: selectedSensors?.length > 0 ? 0.2 : .4,
     getPointRadius: 400,
     getLineWidth: 35,
     getLineColor: (feature) => {
@@ -328,7 +329,7 @@ function MapSection({ mapRef, handlePanMap = (viewState) => {}, setViewStateFn =
       if (!data?.length) {
         return [79, 143, 197];
       }
-      const latest = data?.find(() => true)?.value;
+      const latest = data?.[selectedTimeIndex]?.value;
       if (isSensorOffline(latest)) {
         return [229, 238, 245];
         //return [68, 68, 68];
@@ -373,7 +374,7 @@ function MapSection({ mapRef, handlePanMap = (viewState) => {}, setViewStateFn =
       if (!data?.length) {
         return [79, 143, 197];
       }
-      const latest = data?.find(() => true)?.value;
+      const latest = data?.[selectedTimeIndex]?.value;
       if (isSensorOffline(latest)) {
         //return [79, 143, 197];
         return [100, 100, 100];
@@ -384,7 +385,7 @@ function MapSection({ mapRef, handlePanMap = (viewState) => {}, setViewStateFn =
       }
       return scaleColor(latest, bins, pm2_5Ranges.map(r => r.colorComponents));
     },
-    opacity: 0.85,
+    opacity: 0.2,
     getPointRadius: 400,
     getLineWidth: 35,
     getLineColor: (feature) => {
@@ -393,7 +394,7 @@ function MapSection({ mapRef, handlePanMap = (viewState) => {}, setViewStateFn =
       if (!data?.length) {
         return [229, 238, 245];
       }
-      const latest = data?.find(() => true)?.value;
+      const latest = data?.[selectedTimeIndex]?.value;
       if (isSensorOffline(latest)) {
         //return [229, 238, 245];
         //return [68, 68, 68];
@@ -441,7 +442,7 @@ function MapSection({ mapRef, handlePanMap = (viewState) => {}, setViewStateFn =
       if (!data?.length) {
         return [79, 143, 197];
       }
-      const latest = data?.find(() => true)?.value;
+      const latest = data?.[selectedTimeIndex]?.value;
       if (isSensorOffline(latest)) {
       //return [79, 143, 197];
         return [100, 100, 100];
@@ -452,7 +453,7 @@ function MapSection({ mapRef, handlePanMap = (viewState) => {}, setViewStateFn =
       }
       return scaleColor(latest, bins, pm2_5Ranges.map(r => r.colorComponents));
     },
-    opacity: 0.85,
+    opacity: 0.2,
     getPointRadius: 400,
     getLineWidth: 35,
     getLineColor: (feature) => {
@@ -462,7 +463,7 @@ function MapSection({ mapRef, handlePanMap = (viewState) => {}, setViewStateFn =
         return [229, 238, 245];
       }
 
-      const latest = data?.find(() => true)?.value;
+      const latest = data?.[selectedTimeIndex]?.value;
       if (latest === "None" || latest === "NaN" || latest === null || latest === undefined) {
         //return [229, 238, 245];
         //return [68, 68, 68];
@@ -488,7 +489,7 @@ function MapSection({ mapRef, handlePanMap = (viewState) => {}, setViewStateFn =
         popupContent: `{"id": "datasourceId"}`
       }})}
   }),
-  ], [dispatch, clickedSensor, geojsonData, selectedSensors, setSearchParams, selectedParameter, bins]);
+  ], [dispatch, selectedTimeIndex, clickedSensor, geojsonData, selectedSensors, setSearchParams, selectedParameter, bins]);
 
   useEffect(() => {
     setViewStateFn(setViewState);

--- a/src/components/Map/ParquetReaderComponent.js
+++ b/src/components/Map/ParquetReaderComponent.js
@@ -78,9 +78,22 @@ const ParquetReaderComponent = ({ DEBUG }) => {
       rowEnd: 2,
     }).then(data => {
       dispatch(setMetricData({ parameter: selectedParameter, data }));
-
       const endTime = new Date().getTime();
       console.log(`Finished fetching initial map data: ${endTime - startTime}ms`);
+    });
+  }, [dispatch, locations, selectedParameter]);
+
+  useEffect(() => {
+    // Fetch initial timestamp for the historical slider
+    const startTime = new Date().getTime();
+    fetchPq({
+      url: `${s3prefix}/${selectedParameter}.parquet.brotli`,
+      columns: ['type', 'date']
+    }).then(data => {
+      dispatch(setMetricData({ parameter: selectedParameter, data }));
+
+      const endTime = new Date().getTime();
+      console.log(`Finished fetching historical timestamps: ${endTime - startTime}ms`);
     });
   }, [dispatch, locations, selectedParameter]);
 

--- a/src/components/Map/ParquetReaderComponent.js
+++ b/src/components/Map/ParquetReaderComponent.js
@@ -8,6 +8,7 @@ import {
   setMetricData,
   selectMetricData,
   setMetricIndex, selectMetrics, selectClickedSensor, selectBreadcrumbs, selectMetricIndex, selectAverageType,
+  selectSelectedTimeIndex,
 } from '../../store/slices/sensorDataSlice';
 import {fetchPq} from "../VariablePanel/common";
 
@@ -29,6 +30,7 @@ const ParquetReaderComponent = ({ DEBUG }) => {
   const breadcrumbs = useSelector(selectBreadcrumbs);
   const metricIndex = useSelector(selectMetricIndex);
   const averageType = useSelector(selectAverageType);
+  const selectedTimeIndex = useSelector(selectSelectedTimeIndex);
 
   // Awareness of current dataset
   // TODO: Only fetch new data if we don't already have it?
@@ -105,7 +107,7 @@ const ParquetReaderComponent = ({ DEBUG }) => {
     });
   }, [dispatch, clickedSensor, selectedParameter]);
 
-  // Fetch latest row(s) of PM2.5 when Details panel opens
+  // Fetch latest row(s) for selected parameter when Details panel opens
   useEffect(() => {
     const currentPage = breadcrumbs[breadcrumbs.length - 1];
     if (!clickedSensor || currentPage !== 'Details') {
@@ -127,6 +129,21 @@ const ParquetReaderComponent = ({ DEBUG }) => {
       });
     });
   }, [dispatch, clickedSensor, breadcrumbs]);
+
+  useEffect(() => {
+    // Fetch initial metric data for the map
+    const startTime = new Date().getTime();
+    fetchPq({
+      url: `${s3prefix}/${selectedParameter}.parquet.brotli`,
+      rowStart: selectedTimeIndex,
+      rowEnd: selectedTimeIndex+1,
+    }).then(data => {
+      dispatch(setMetricData({ parameter: selectedParameter, data }));
+
+      const endTime = new Date().getTime();
+      console.log(`Finished fetching ${selectedParameter} map data for index=${selectedTimeIndex}: ${endTime - startTime}ms`);
+    });
+  }, [dispatch, locations, selectedParameter, selectedTimeIndex]);
 
   useEffect(() => {
     const currentPage = breadcrumbs[breadcrumbs.length - 1];

--- a/src/components/Pages/About.js
+++ b/src/components/Pages/About.js
@@ -143,24 +143,81 @@ const faqCategories = [
   { id: 'parameters', label: 'Parameters' }
 ];
 
+const ExternalLink = styled.a`
+    text-decoration: none;
+    color: #005899;
+    font-weight: 700;
+`;
+
 const faqs = [
   {
     id: 'map-data-access',
     category: 'map',
     question: "How can I access the data?",
-    answer: "Explore the Map to explore sensor-specific and regional data trends. Data can also be downloaded in a number of ways, including: direct download on this website (see 'Download' links on Map), direct download on the City Data Portal, and direct download on the Open Air Clarity Dashboard."
+    answer: <>
+      Explore the Map to explore sensor-specific, community/neighborhood-specific, or city-
+      wide data trends. Data can also be downloaded in a number of ways, including direct download on
+      this website (see 'Download' links on Map), direct download on the{" "}
+      <ExternalLink href="https://data.cityofchicago.org/Health-Human-Services/Open-Air-Chicago-Individual-Measurements/xfya-dxtq/about_data"
+                    target={'_blank'} rel="noreferrer noopener">
+        City Data Portal
+      </ExternalLink>, and direct download on the{" "}
+      <ExternalLink href="https://map.clarity.io/open-air-chicago"
+                    target={'_blank'} rel="noreferrer noopener">
+        {platformName} Clarity Dashboard
+      </ExternalLink>.
+    </>
   },
   {
     id: 'map-colors',
     category: 'map',
     question: "What do the colors on the map mean?",
-    answer: "Colors of individual sensor locations correspond to different value bins or groupings of air quality metrics. To identify the value range and corresponding advisory for each color, use the legend 'key' on the top left part of the mapping application."
+    answer: <>
+      Colors of individual sensor locations correspond to different value bins or groupings
+      of EPA’s Air Quality Index (AQI). The U.S. Air Quality Index (AQI) is EPA's tool for
+      communicating about outdoor air quality and health. The AQI includes six color-coded
+      categories, each corresponding to a range of index values representing a different
+      level of health concern. For example, while AQI value of 50 or below represents good
+      air quality, an AQI value over 300 represents hazardous air quality. To identify the
+      value range and corresponding advisory for each color, use the legend 'key' on the
+      top left part.
+    </>
+  },
+  {
+    id: 'map-data-howtouse',
+    category: 'map',
+    question: "How can I use the data to protect myself from harmful exposures to air pollutants?",
+    answer: <>
+      We highly recommend checking the map regularly and understanding the trends in
+      air quality in your neighborhood. On days when the Air Quality Index (AQI) is
+      unhealthy (i.e., greater than 100), we recommend using our Map as a “Public
+      Health Messaging Tool” and adjust your daily activities to reduce your exposures
+      to air pollutants and associated health risks.
+      <br />
+      <br />
+      Specifically, we recommend adopting one or more of the{" "}
+      <ExternalLink href="https://www.epa.gov/wildfire-smoke-course/strategies-reduce-exposure-outdoors"
+                    target={'_blank'} rel="noreferrer noopener">
+        Strategies to Reduce Exposure Outdoors
+      </ExternalLink>
+      {" "}(e.g., staying indoors, adjusting outdoor activities (e.g., running) at time frames when the air quality is healthy, using an N95 mask, etc.)
+    </>
   },
   {
     id: 'protocol-data-source',
     category: 'protocol',
-    question: "Where does this data come from and where is it stored?",
-    answer: "This data comes from Clarity sensor measurements of the Open Air Network, a co-owned sensor project between the University of Illinois and the Chicago Department of Public Health. Sensor readings are pulled directly from the Clarity programming interface, cleaned, summarized, and updated in this web mapping application. A copy of the data is stored in a U.S.-based web server. Data can be directly downloaded by time period of interest (e.g. hourly, monthly, seasonal) in the 'Details' section of the mapping interface. The University of Illinois is engaged in independent quality assurance and quality control of the data."
+    question: "Where does the data come from and where it is stored?",
+    answer: <>
+      The data represent the Clarity Node-S sensor measurements for Fine Particulate Matter (PM2.5)
+      and Nitrogen Dioxide (NO2) of the “Open Air Chicago” network, a co-owned sensor-based air
+      monitoring and air quality assessment project between the University of Illinois at
+      Chicago and the Chicago Department of Public Health. Sensor readings are pulled directly
+      from the Clarity programming interface, cleaned, summarized, and updated in this web mapping
+      application. The data cleaning and data quality assurance and quality control protocols are
+      employed by Clarity (see below for more details). A copy of the data is stored on a U.S.-based
+      web server. Data can be directly downloaded by time period of interest (e.g., hourly, monthly,
+      seasonally) in the 'Details' section of the mapping interface.
+    </>
   },
   {
     id: 'protocol-sensor-owner',
@@ -294,22 +351,20 @@ export default function About() {
                  Health (CDPH), in collaboration with 13 community organizations serving on the city’s
                  advisory board, seven of which were UIC’s official community partners under the UIC
                  grants (CEJN, ASE, SETF, PCR, PERRO, LVEJO, and N4EJ). Please refer to CDPH website to{" "}
-                 <a href="https://www.chicago.gov/city/en/depts/cdph/supp_info/Environment/open-air-chicago.html"
-                    style={{ textDecoration: 'none', color: '#005899', fontWeight: 700 }}
+                 <ExternalLink href="https://www.chicago.gov/city/en/depts/cdph/supp_info/Environment/open-air-chicago.html"
                     target={'_blank'} rel="noreferrer noopener">
                    learn about the “Open Air Chicago” Partner Organizations
-                 </a>.
+                 </ExternalLink>.
                </Grid>
                <Grid size={12} marginTop={'1rem'} style={{ fontFamily: 'Space Grotesk', fontSize: '18px', color: '#444444' }}>
                  The UIC and UIUC teams are the technical architects of the design of the “Open Air Chicago” air monitoring network. We adopted the technical principles behind EPA’s Network Design Criteria for Ambient Air Quality Monitoring under the
                  Clean Air Act to create a neighborhood scale grid-based design, overlaying the grid-based design
                  on the Environmental Justice (EJ) Index Score map generated by CDPH through a comprehensive
                  stakeholder participatory process in 2023 under the{" "}
-                 <a href="https://www.chicago.gov/city/en/depts/env/supp_info/cumulative-impact-assessment.html"
-                    style={{ textDecoration: 'none', color: '#005899', fontWeight: 700 }}
+                 <ExternalLink href="https://www.chicago.gov/city/en/depts/env/supp_info/cumulative-impact-assessment.html"
                     target={'_blank'} rel="noreferrer noopener">
                    Cumulative Impact Assessment project
-                 </a>. Neighborhoods in or near EJ zones have a grid size of 1.4 km x 1.4 km (i.e., 0.87 miles x 0.87 miles),
+                 </ExternalLink>. Neighborhoods in or near EJ zones have a grid size of 1.4 km x 1.4 km (i.e., 0.87 miles x 0.87 miles),
                  and non-EJ areas have a grid size of 1.5 x 1.5 km (0.93 miles x 0.93 miles). This means that there
                  are sensors across Chicago less than 1 mile from each other in every direction. This design,
                  generating concentrations upwind and downwind of a given location, is particularly advantageous
@@ -324,9 +379,8 @@ export default function About() {
                  quality to community organization staff.
                </Grid>
                <Grid size={12} marginTop={'1rem'} style={{ fontFamily: 'Space Grotesk', fontSize: '18px', color: '#444444' }}>
-                 <a href="https://publichealth.uic.edu/profiles/serap-erdal/"
-                    style={{ textDecoration: 'none', color: '#005899', fontWeight: 700 }}
-                    target={'_blank'} rel="noreferrer noopener">Dr. Serap Erdal</a>
+                 <ExternalLink href="https://publichealth.uic.edu/profiles/serap-erdal/"
+                    target={'_blank'} rel="noreferrer noopener">Dr. Serap Erdal</ExternalLink>
                  {" "}from UIC led the scientific and community engagement process of network
                  development and is the principal Investigator of two grants, the National Institute of
                  Standard and Technology (NIST) (i.e., a Congressional Earmark from Senator Tammy Duckworth

--- a/src/components/Pages/Map.js
+++ b/src/components/Pages/Map.js
@@ -8,6 +8,7 @@ import {
 } from "../../components";
 import { selectMapParams } from "../../store/slices/legacyStoreSlice";
 import { AQColorScale } from "../VariablePanel/AQColorScale";
+import {HistoricalTimeslider} from "../VariablePanel/HistoricalTimeslider";
 
 // US bounds
 export const defaultBounds = fitBounds({
@@ -42,6 +43,7 @@ function Map() {
             {/*<VariablePanel />*/}
             <DataPanel mapRef={mapRef} handlePanMap={handlePanMap} />
             <AQColorScale />
+            <HistoricalTimeslider />
           </>
         }
       </div>

--- a/src/components/VariablePanel/AQColorScale.js
+++ b/src/components/VariablePanel/AQColorScale.js
@@ -17,7 +17,8 @@ const ColorScaleContainer = styled.div`
   border: 1px solid rgba(65, 182, 230, 1);
   width: 433px;
   left: ${({ $open }) => $open ? '2rem' : '0'};
-  top: ${({ $large }) => $large ? '2rem' : '0'};
+  top: ${({ $large }) => $large ? 'auto' : '0'};
+  bottom: ${({ $large }) => $large ? '2rem' : 'auto'};
   background: rgba( 255, 255, 255, 0.85 );
   box-shadow: 0 8px 32px 0 rgba( 31, 38, 135, 0.85 );
   backdrop-filter: blur( 20px );

--- a/src/components/VariablePanel/HistoricalTimeslider.js
+++ b/src/components/VariablePanel/HistoricalTimeslider.js
@@ -153,7 +153,7 @@ export const HistoricalTimeslider = () => {
   const handleOpenClose = () => dispatch(setPanelState({ history: !panelState.history }));
   const [value, setValue] = useState(30);
 
-  const fromIso = (d) => new Date(d.split(' ').join('T') + 'Z')
+  const fromIso = (d) => new Date(d?.split(' ').join('T') + 'Z');
   const getStartDate = useCallback((endDate: Date): Date => {
     const startDate = new Date(endDate);
     if (granularity === 'day') {

--- a/src/components/VariablePanel/HistoricalTimeslider.js
+++ b/src/components/VariablePanel/HistoricalTimeslider.js
@@ -1,0 +1,247 @@
+// AQColorScale.js
+import {colors} from "../../config";
+import styled from "styled-components";
+import Grid from "@mui/material/Grid";
+import useMediaQuery from "@mui/material/useMediaQuery";
+import {selectPanelState, setPanelState} from "../../store/slices/legacyStoreSlice";
+import {useDispatch, useSelector} from "react-redux";
+import {FaHistory} from "react-icons/fa";
+import FormControl from "@mui/material/FormControl";
+import Select from "@mui/material/Select";
+import {
+  selectAverageType, selectMetricData,
+  selectMetricIndex,
+  selectSelectedTimeIndex, selectSensorParameter,
+  setAverageType
+} from "../../store/slices/sensorDataSlice";
+import MenuItem from "@mui/material/MenuItem";
+import {Slider} from "@mui/material";
+import {useCallback, useMemo, useState} from "react";
+
+//// Styled components CSS
+// Main container for entire panel
+const TimesliderContainer = styled.div`
+  position: fixed;
+  border-radius: 8px;
+  border: 1px solid rgba(65, 182, 230, 1);
+  width: 433px;
+  left: ${({ $open }) => $open ? '2rem' : '0'};
+  top: ${({ $large }) => $large ? '2rem' : '0'};
+  background: rgba( 255, 255, 255, 0.85 );
+  box-shadow: 0 8px 32px 0 rgba( 31, 38, 135, 0.85 );
+  backdrop-filter: blur( 20px );
+  -webkit-backdrop-filter: blur( 20px );
+  box-shadow: ${({ $open }) => $open ? `2px 0px 5px ${colors.gray}44` : 'none'};
+  border:1px solid ${colors.chicagoBlue};
+  padding: 24px 27px;
+  box-sizing: border-box;
+  transition:250ms all;
+  font-family: 'Roboto', sans-serif;
+  color:${colors.black};
+  font-size:100%;
+  z-index:7;
+  transform: ${({ $large, $open }) => $open ? 'none' : ($large ? 'translateX(calc(-100%))' : 'translateX(calc(-100% - 1em))')};
+
+  #avgTypeSelectHistorical div {
+      font-family: Space Grotesk;
+      font-size: 16px;
+      font-weight: 400;
+      padding: 0.4rem 0.4rem;
+  }
+    
+    @media (max-width:600px) {
+        width:calc(100% - 1em); 
+        bottom:calc(1em + 45px);
+        height: max-content; // calc(100% - 55em);
+        top:.5em;
+        left: ${({ $large, $open }) => $open ?  '.5em' : '' };
+        padding-top: 2em;
+        z-index:51;
+        display: ${props => (props.otherPanels || props.dataLength === 0) ? 'none' : 'initial'};
+    }
+
+    button#showHideRight {
+        position:absolute;
+        top:20px;
+        right: ${({  $open }) => $open ? '-20px' : '-60px'};
+        width:40px;
+        height:40px;
+        padding:0;
+        margin:0;
+        background-color: ${colors.white};
+        box-shadow: 2px 0px 2px ${colors.gray}44;
+        border:1px solid ${colors.chicagoBlue};
+        // border-radius:20px;
+        cursor: pointer;
+        transition:500ms all;
+        svg {
+            width:15px;
+            height:15px;
+            margin:12.5px 0 0 0;
+            @media (max-width:600px){
+                margin:5px;
+            }
+            fill:${colors.gray};
+            transform:rotate(180deg);
+            transition:500ms all;
+        }
+        :after {
+            opacity:0;
+            font-weight:bold;
+            color:${colors.gray};
+            position: relative;
+            top:-17px;
+            transition:500ms all;
+            content: 'Report';
+            right:50px;
+            z-index:4;
+        }
+        &.hidden {
+            svg {
+                transform:rotate(0deg);
+            }
+            :after {
+                opacity:1;
+            }
+        }
+        @media (max-width:768px) {
+            top:120px;
+        }
+        @media (max-width:600px) {
+            left:calc(100% + 4.5em);
+            width:3em;
+            height:3em;
+            top:0;
+            &.hidden svg {
+                transform:rotate(0deg);
+            }
+            :after {
+                display:none;
+            }
+            &.active {
+                left:90%;
+            }
+            &.active svg {
+                transform:rotate(90deg);
+            }
+        }
+    }
+    
+`;
+
+const HistoryIcon = styled(FaHistory)`
+    height: 16px;
+    color: rgba(0, 88, 153, 0.5);
+`;
+
+const SliderLabel = styled.span`
+    font-family: Space Grotesk, sans-serif;
+    font-size: 14px;
+    font-weight: 400;
+`;
+
+export const HistoricalTimeslider = () => {
+  const largeScreen = useMediaQuery('(min-width: 600px)');
+
+  const dispatch = useDispatch();
+  const panelState = useSelector(selectPanelState);
+  const [granularity, setGranularity] = useState('day');
+
+  // Find data points when granularity changes
+  const metricIndex = useSelector(selectMetricIndex);
+  const selectedTimeIndex = useSelector(selectSelectedTimeIndex);
+  const metricData = useSelector(selectMetricData);
+  const selectedParameter = useSelector(selectSensorParameter);
+
+  const handleOpenClose = () => dispatch(setPanelState({ history: !panelState.history }));
+  const [value, setValue] = useState(30);
+
+  const handleChange = (event, newValue) => { setValue(newValue); };
+
+  const getStartDate = (endDate: Date): Date => {
+    const startDate = new Date(endDate);
+    if (granularity === 'day') {
+      // show "Last Day" => start = 1 day ago ~ end - 1 day
+      startDate.setDate(endDate.getDate() - 1);
+    } else if (granularity === 'week') {
+      // show "Last Week" => start = 7 days ago ~ end - 7 days
+      startDate.setDate(endDate.getDate() - 7);
+    } else if (granularity === 'month') {
+      // show "Last Month" => start = 30 days ago ~ end - 30 days
+      startDate.setDate(endDate.getDate() - 30);
+    } else if (granularity === 'season') {
+      // show "Last Season" => start = 3 months ago ~ end - 90 days
+      startDate.setDate(endDate.getDate() - 90);
+    } else if (granularity === 'year') {
+      // show "Last Year" => start = 1 year ago ~ end - 365 days
+      startDate.setDate(endDate.getDate() - 365);
+    }
+    return startDate;
+  }
+
+  const historicalSlice = useMemo(() => {
+    const endDate = new Date(metricData?.[0]?.date);
+    const startDate = getStartDate(endDate);
+
+    const filtered = metricData?.filter((m) => m?.date > startDate?.toISOString());
+    console.log(filtered);
+    return filtered;
+  }, [metricData, getStartDate]);
+
+  const [sliderStart: Date, sliderEnd: Date] = useMemo(() => {
+    // Select dataset based on granularity
+    // Filter by time, unless user chooses "all"
+    const data = granularity === 'all' ? metricData : historicalSlice;
+
+    // Determine start + end dates based on our historical slice
+    const endDate = new Date(data?.[0]?.date);
+    const end = endDate.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+    const startDate = new Date(data?.[data?.length - 1]?.date);
+    const start = startDate.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+
+    return [start, end];
+  }, [granularity, metricData, historicalSlice]);
+
+  return (
+    <TimesliderContainer $large={largeScreen} $open={panelState.history}>
+      <Grid container spacing={0} alignItems={'center'} justifyContent={'space-between'}>
+        <Grid size={{ xs: 6 }} style={{ fontFamily: 'Lexend', fontWeight: 400, fontSize: '18px', color: 'rgba(68, 68, 68, 1)' }}>
+          <HistoryIcon /> Historical Trends
+        </Grid>
+        <Grid size={{ xs:4 }}>
+          <FormControl id="avgTypeSelectHistorical" variant="outlined" fullWidth>
+            <Select
+              variant={"outlined"}
+              value={granularity}
+              onChange={(e) => setGranularity(e.target.value)}
+            >
+              <MenuItem value="day" disabled={metricIndex.day <= 0}>Last Day</MenuItem>
+              <MenuItem value="week" disabled={metricIndex.week <= 0}>Last Week</MenuItem>
+              <MenuItem value="month" disabled={metricIndex.month <= 0}>Last Month</MenuItem>
+              <MenuItem value="season" disabled={metricIndex.season <= 0}>Last Season</MenuItem>
+              <MenuItem value="year" disabled={metricIndex.year <= 0}>Last Year</MenuItem>
+              <MenuItem value="all">All Time</MenuItem>
+            </Select>
+          </FormControl>
+        </Grid>
+      </Grid>
+
+      <Grid marginTop={'1.5rem'}>
+        <Grid container alignItems={'center'}>
+          <Grid size={{ xs: 2 }}>
+            <SliderLabel>{sliderStart}</SliderLabel>
+          </Grid>
+          <Grid size={{ xs: 8 }}>
+            <Slider aria-label="History" value={value} onChange={handleChange} />
+          </Grid>
+          <Grid size={{ xs: 2 }} textAlign={'end'}>
+            <SliderLabel>{sliderEnd}</SliderLabel>
+          </Grid>
+        </Grid>
+      </Grid>
+
+      <button onClick={handleOpenClose} id="showHideRight" className={panelState.history ? 'active' : 'hidden'}><FaHistory /></button>
+    </TimesliderContainer>
+  );
+}
+

--- a/src/components/VariablePanel/HistoricalTimeslider.js
+++ b/src/components/VariablePanel/HistoricalTimeslider.js
@@ -9,14 +9,12 @@ import {FaHistory} from "react-icons/fa";
 import FormControl from "@mui/material/FormControl";
 import Select from "@mui/material/Select";
 import {
-  selectAverageType, selectMetricData,
+  selectMetricData,
   selectMetricIndex,
-  selectSelectedTimeIndex, selectSensorParameter,
-  setAverageType
 } from "../../store/slices/sensorDataSlice";
 import MenuItem from "@mui/material/MenuItem";
 import {Slider} from "@mui/material";
-import {useCallback, useMemo, useState} from "react";
+import {useMemo, useState} from "react";
 
 //// Styled components CSS
 // Main container for entire panel
@@ -149,30 +147,28 @@ export const HistoricalTimeslider = () => {
 
   // Find data points when granularity changes
   const metricIndex = useSelector(selectMetricIndex);
-  const selectedTimeIndex = useSelector(selectSelectedTimeIndex);
   const metricData = useSelector(selectMetricData);
-  const selectedParameter = useSelector(selectSensorParameter);
 
   const handleOpenClose = () => dispatch(setPanelState({ history: !panelState.history }));
   const [value, setValue] = useState(30);
 
   const handleChange = (event, newValue) => { setValue(newValue); };
 
-  const getStartDate = (endDate: Date): Date => {
+  const getStartDate = (endDate: Date, scale: string): Date => {
     const startDate = new Date(endDate);
-    if (granularity === 'day') {
+    if (scale === 'day') {
       // show "Last Day" => start = 1 day ago ~ end - 1 day
       startDate.setDate(endDate.getDate() - 1);
-    } else if (granularity === 'week') {
+    } else if (scale === 'week') {
       // show "Last Week" => start = 7 days ago ~ end - 7 days
       startDate.setDate(endDate.getDate() - 7);
-    } else if (granularity === 'month') {
+    } else if (scale === 'month') {
       // show "Last Month" => start = 30 days ago ~ end - 30 days
       startDate.setDate(endDate.getDate() - 30);
-    } else if (granularity === 'season') {
+    } else if (scale === 'season') {
       // show "Last Season" => start = 3 months ago ~ end - 90 days
       startDate.setDate(endDate.getDate() - 90);
-    } else if (granularity === 'year') {
+    } else if (scale === 'year') {
       // show "Last Year" => start = 1 year ago ~ end - 365 days
       startDate.setDate(endDate.getDate() - 365);
     }
@@ -181,12 +177,12 @@ export const HistoricalTimeslider = () => {
 
   const historicalSlice = useMemo(() => {
     const endDate = new Date(metricData?.[0]?.date);
-    const startDate = getStartDate(endDate);
+    const startDate = getStartDate(endDate, granularity);
 
     const filtered = metricData?.filter((m) => m?.date > startDate?.toISOString());
     console.log(filtered);
     return filtered;
-  }, [metricData, getStartDate]);
+  }, [metricData, granularity]);
 
   const [sliderStart: Date, sliderEnd: Date] = useMemo(() => {
     // Select dataset based on granularity

--- a/src/components/VariablePanel/HistoricalTimeslider.js
+++ b/src/components/VariablePanel/HistoricalTimeslider.js
@@ -10,7 +10,7 @@ import FormControl from "@mui/material/FormControl";
 import Select from "@mui/material/Select";
 import {
   selectMetricData,
-  selectMetricIndex,
+  selectMetricIndex, selectSelectedTimeIndex, setSelectedTimeIndex,
 } from "../../store/slices/sensorDataSlice";
 import MenuItem from "@mui/material/MenuItem";
 import {Slider} from "@mui/material";
@@ -152,51 +152,104 @@ export const HistoricalTimeslider = () => {
   const handleOpenClose = () => dispatch(setPanelState({ history: !panelState.history }));
   const [value, setValue] = useState(30);
 
-  const handleChange = (event, newValue) => { setValue(newValue); };
-
+  const fromIso = (d) => new Date(d.split(' ').join('T') + 'Z')
   const getStartDate = (endDate: Date, scale: string): Date => {
     const startDate = new Date(endDate);
     if (scale === 'day') {
       // show "Last Day" => start = 1 day ago ~ end - 1 day
       startDate.setDate(endDate.getDate() - 1);
+      const firstDataPoint = metricData?.filter(m => m?.type === 'hour')?.reverse()?.find((m) => fromIso(m?.date)?.getTime() > startDate?.getTime());
+      return fromIso(firstDataPoint?.date);
     } else if (scale === 'week') {
       // show "Last Week" => start = 7 days ago ~ end - 7 days
       startDate.setDate(endDate.getDate() - 7);
+      const firstDataPoint = metricData?.filter(m => m?.type === 'hour')?.reverse()?.find((m) => fromIso(m?.date)?.getTime() > startDate?.getTime());
+      return fromIso(firstDataPoint?.date);
     } else if (scale === 'month') {
-      // show "Last Month" => start = 30 days ago ~ end - 30 days
-      startDate.setDate(endDate.getDate() - 30);
+      // show "Last Month" => start = 1 month ago ~ end - 1 month
+      startDate.setMonth(endDate.getMonth() - 1);
+      const firstDataPoint = metricData?.filter(m => m?.type === 'hour')?.reverse()?.find((m) => fromIso(m?.date)?.getTime() > startDate?.getTime());
+      return fromIso(firstDataPoint?.date);
     } else if (scale === 'season') {
-      // show "Last Season" => start = 3 months ago ~ end - 90 days
-      startDate.setDate(endDate.getDate() - 90);
+      // show "Last Season" => start = 3 months ago ~ end - 3 months
+      startDate.setMonth(endDate.getMonth() - 3);
+      const firstDataPoint = metricData?.filter(m => m?.type === 'hour')?.reverse()?.find((m) => fromIso(m?.date)?.getTime() > startDate?.getTime());
+      return fromIso(firstDataPoint?.date);
     } else if (scale === 'year') {
-      // show "Last Year" => start = 1 year ago ~ end - 365 days
-      startDate.setDate(endDate.getDate() - 365);
+      // show "Last Year" => start = 1 year ago ~ end - 1 year
+      startDate.setFullYear(endDate.getFullYear() - 1);
+      const firstDataPoint = metricData?.filter(m => m?.type === 'hour')?.reverse()?.find((m) => fromIso(m?.date)?.getTime() > startDate?.getTime());
+      return fromIso(firstDataPoint?.date);
+    } else if (scale === 'all') {
+      return new Date(metricData?.filter(m => m?.type === 'hour')?.reverse()?.find(() => true)?.date.split(' ').join('T') + 'Z');
     }
     return startDate;
   }
 
   const historicalSlice = useMemo(() => {
-    const endDate = new Date(metricData?.[0]?.date);
+    const hourlyData = metricData?.filter(m => m?.type === 'hour')
+    const endDateIso = hourlyData?.find(() => true)?.date;
+    const endDate = new Date(endDateIso);
     const startDate = getStartDate(endDate, granularity);
+    return hourlyData?.filter(m =>
+      new Date(m?.date?.split(' ').join('T') + 'Z')?.getTime() > startDate?.getTime() && endDate?.getTime() < new Date(m?.date?.split(' ').join('T') + 'Z')?.getTime());
+  }, [metricData, granularity, getStartDate]);
 
-    const filtered = metricData?.filter((m) => m?.date > startDate?.toISOString());
-    console.log(filtered);
-    return filtered;
-  }, [metricData, granularity]);
+
+  function valuetext(value, length) {
+    const offset = length - value;
+    const isoDate = metricData?.filter(m => m?.type === 'hour')?.[offset]?.date?.split(' ').join('T') + 'Z';
+    return new Date(isoDate)?.toLocaleTimeString('en-US', { month: 'short', day: 'numeric', hour: 'numeric' });
+  }
 
   const [sliderStart: Date, sliderEnd: Date] = useMemo(() => {
     // Select dataset based on granularity
     // Filter by time, unless user chooses "all"
-    const data = granularity === 'all' ? metricData : historicalSlice;
+    //const data = granularity === 'all' ? metricData : historicalSlice;
 
     // Determine start + end dates based on our historical slice
-    const endDate = new Date(data?.[0]?.date);
+    //const endDate = new Date(data?.[0]?.date.split(' ').join('T') + 'Z');
+    const endDateIso = metricData?.filter(m => m?.type === 'hour')?.find(() => true)?.date.split(' ').join('T') + 'Z';
+    const endDate = new Date(endDateIso);
+
     const end = endDate.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
-    const startDate = new Date(data?.[data?.length - 1]?.date);
+    //const startDate = new Date(data?.[data?.length - 1]?.date.split(' ').join('T') + 'Z');
+    const startDate = getStartDate(endDate, granularity);
     const start = startDate.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
 
     return [start, end];
-  }, [granularity, metricData, historicalSlice]);
+  }, [granularity, getStartDate]);
+
+  const numTicks = () => {
+    const now = new Date();
+    if (granularity === 'day') {
+      const dayAgo = new Date()?.setTime(now?.getTime() - 24*60*60*1000);  // 24 hours
+      return metricData?.filter(m => m?.type === 'hour' && fromIso(m?.date)?.getTime() > dayAgo)?.length;
+    } else if (granularity === 'week') {
+      const weekAgo = new Date()?.setTime(now?.getTime() - 7*24*60*60*1000);  // 7 days
+      return metricData?.filter(m => m?.type === 'hour' && fromIso(m?.date)?.getTime() > weekAgo)?.length;
+    } else if (granularity === 'month') {
+      const monthAgo = new Date()?.setTime(now?.getTime() - 30*24*60*60*1000);  // 30 days
+      return metricData?.filter(m => m?.type === 'hour' && fromIso(m?.date)?.getTime() > monthAgo)?.length;
+    } else if (granularity === 'season') {
+      const threeMonthsAgo = new Date()?.setTime(now?.getTime() - 3*30*24*60*60*1000);  // 90 days
+      return metricData?.filter(m => m?.type === 'hour' && fromIso(m?.date)?.getTime() > threeMonthsAgo)?.length;
+    } else if (granularity === 'year') {
+      const oneYearAgo = new Date()?.setTime(now?.getTime() - 365*24*60*60*1000);  // 24 hours
+      return metricData?.filter(m => m?.type === 'hour' && fromIso(m?.date)?.getTime() > oneYearAgo)?.length;
+    } else {
+      return metricData?.filter(m => m?.type === 'hour')?.length;
+    }
+  }
+
+  const handleChange = (event, newValue) => { setValue(newValue); };
+  const handleCommit = (event, finalValue) => {
+    const index = numTicks() - finalValue;
+    console.log("Triggered only when mouse is released:", index);
+    // Call your API or heavy logic here
+
+    dispatch(setSelectedTimeIndex({ index }));
+  };
 
   return (
     <TimesliderContainer $large={largeScreen} $open={panelState.history}>
@@ -204,18 +257,18 @@ export const HistoricalTimeslider = () => {
         <Grid size={{ xs: 6 }} style={{ fontFamily: 'Lexend', fontWeight: 400, fontSize: '18px', color: 'rgba(68, 68, 68, 1)' }}>
           <HistoryIcon /> Historical Trends
         </Grid>
-        <Grid size={{ xs:4 }}>
+        <Grid size={{ xs: 5 }}>
           <FormControl id="avgTypeSelectHistorical" variant="outlined" fullWidth>
             <Select
               variant={"outlined"}
               value={granularity}
               onChange={(e) => setGranularity(e.target.value)}
             >
-              <MenuItem value="day" disabled={metricIndex.day <= 0}>Last Day</MenuItem>
-              <MenuItem value="week" disabled={metricIndex.week <= 0}>Last Week</MenuItem>
-              <MenuItem value="month" disabled={metricIndex.month <= 0}>Last Month</MenuItem>
-              <MenuItem value="season" disabled={metricIndex.season <= 0}>Last Season</MenuItem>
-              <MenuItem value="year" disabled={metricIndex.year <= 0}>Last Year</MenuItem>
+              <MenuItem value="day" disabled={metricIndex.day <= 0}>Past Day</MenuItem>
+              <MenuItem value="week" disabled={metricIndex.week <= 0}>Past Week</MenuItem>
+              <MenuItem value="month" disabled={metricIndex.month <= 0}>Past Month</MenuItem>
+              <MenuItem value="season" disabled={metricIndex.season <= 0}>Past 3 Months</MenuItem>
+              <MenuItem value="year" disabled={metricIndex.year <= 0}>Past Year</MenuItem>
               <MenuItem value="all">All Time</MenuItem>
             </Select>
           </FormControl>
@@ -225,13 +278,53 @@ export const HistoricalTimeslider = () => {
       <Grid marginTop={'1.5rem'}>
         <Grid container alignItems={'center'}>
           <Grid size={{ xs: 2 }}>
-            <SliderLabel>{sliderStart}</SliderLabel>
+            { granularity !== 'year' && granularity !== 'all' && <SliderLabel>{sliderStart}</SliderLabel> }
+            { granularity === 'year' && <SliderLabel>{sliderStart}</SliderLabel> }
+            { granularity === 'all' && <SliderLabel>{sliderStart}</SliderLabel> }
           </Grid>
           <Grid size={{ xs: 8 }}>
-            <Slider aria-label="History" value={value} onChange={handleChange} />
+            <Slider aria-label="History"
+                    // Value format & display
+                    getAriaValueText={valuetext}
+                    valueLabelFormat={(value) => valuetext(value, numTicks())}
+                    valueLabelDisplay="on"
+                    value={value}
+
+                    // Numerical behavior
+                    shiftStep={8}
+                    min={0}
+                    max={numTicks()}
+                    onChange={handleChange}
+                    onChangeCommitted={handleCommit}
+
+                    // Custom styling for valueLabel / tooltip
+                    track={false}
+                    sx={{
+                      '& .MuiSlider-rail': {
+                        color: '#41B6E6'
+                      },
+                      '& .MuiSlider-thumb': {
+                        color: '#005899'
+                      },
+                      // Target the value label container
+                      '& .MuiSlider-valueLabel': {
+                        fontSize: 12,
+                        fontWeight: 'normal',
+                        fontFamily: 'Space Grotesk',
+                        top: 50, // Adjust distance from thumb
+                        backgroundColor: '#00000000', // transparent background
+                        color: '#41B6E6', // Change text color
+                        '&::before': {
+                          display: 'none', // Hides the default little arrow bubble point
+                        },
+                      },
+                    }}
+            />
           </Grid>
           <Grid size={{ xs: 2 }} textAlign={'end'}>
-            <SliderLabel>{sliderEnd}</SliderLabel>
+            { granularity !== 'year' && granularity !== 'all' && <SliderLabel>{sliderEnd}</SliderLabel> }
+            { granularity === 'year' && <SliderLabel>{sliderEnd}</SliderLabel> }
+            { granularity === 'all' && <SliderLabel>{sliderEnd}</SliderLabel> }
           </Grid>
         </Grid>
       </Grid>

--- a/src/components/VariablePanel/HistoricalTimeslider.js
+++ b/src/components/VariablePanel/HistoricalTimeslider.js
@@ -189,7 +189,7 @@ export const HistoricalTimeslider = () => {
   const historicalSlice = useMemo(() => {
     const hourlyData = metricData?.filter(m => m?.type === 'hour')
     const endDateIso = hourlyData?.find(() => true)?.date;
-    const endDate = new Date(endDateIso);
+    const endDate = fromIso(endDateIso);
     const startDate = getStartDate(endDate, granularity);
     return hourlyData?.filter(m =>
       new Date(m?.date?.split(' ').join('T') + 'Z')?.getTime() > startDate?.getTime() && endDate?.getTime() < new Date(m?.date?.split(' ').join('T') + 'Z')?.getTime());
@@ -223,11 +223,13 @@ export const HistoricalTimeslider = () => {
   const numTicks = () => {
     const now = new Date();
     if (granularity === 'day') {
-      const dayAgo = new Date()?.setTime(now?.getTime() - 24*60*60*1000);  // 24 hours
-      return metricData?.filter(m => m?.type === 'hour' && fromIso(m?.date)?.getTime() > dayAgo)?.length;
+      return 24;
+      //const dayAgo = new Date()?.setTime(now?.getTime() - 24*60*60*1000);  // 24 hours
+      //return metricData?.filter(m => m?.type === 'hour' && fromIso(m?.date)?.getTime() > dayAgo)?.length;
     } else if (granularity === 'week') {
-      const weekAgo = new Date()?.setTime(now?.getTime() - 7*24*60*60*1000);  // 7 days
-      return metricData?.filter(m => m?.type === 'hour' && fromIso(m?.date)?.getTime() > weekAgo)?.length;
+      return 7*24;
+      //const weekAgo = new Date()?.setTime(now?.getTime() - 7*24*60*60*1000);  // 7 days
+      //return metricData?.filter(m => m?.type === 'hour' && fromIso(m?.date)?.getTime() > weekAgo)?.length;
     } else if (granularity === 'month') {
       const monthAgo = new Date()?.setTime(now?.getTime() - 30*24*60*60*1000);  // 30 days
       return metricData?.filter(m => m?.type === 'hour' && fromIso(m?.date)?.getTime() > monthAgo)?.length;
@@ -247,6 +249,8 @@ export const HistoricalTimeslider = () => {
     const index = numTicks() - finalValue;
     console.log("Triggered only when mouse is released:", index);
     // Call your API or heavy logic here
+
+    console.log(`Now showing on the map: ${index}`);
 
     dispatch(setSelectedTimeIndex({ index }));
   };

--- a/src/components/VariablePanel/HistoricalTimeslider.js
+++ b/src/components/VariablePanel/HistoricalTimeslider.js
@@ -10,11 +10,12 @@ import FormControl from "@mui/material/FormControl";
 import Select from "@mui/material/Select";
 import {
   selectMetricData,
-  selectMetricIndex, selectSelectedTimeIndex, setSelectedTimeIndex,
+  selectMetricIndex,
+  setSelectedTimeIndex,
 } from "../../store/slices/sensorDataSlice";
 import MenuItem from "@mui/material/MenuItem";
 import {Slider} from "@mui/material";
-import {useMemo, useState} from "react";
+import {useCallback, useMemo, useState} from "react";
 
 //// Styled components CSS
 // Main container for entire panel
@@ -153,48 +154,38 @@ export const HistoricalTimeslider = () => {
   const [value, setValue] = useState(30);
 
   const fromIso = (d) => new Date(d.split(' ').join('T') + 'Z')
-  const getStartDate = (endDate: Date, scale: string): Date => {
+  const getStartDate = useCallback((endDate: Date): Date => {
     const startDate = new Date(endDate);
-    if (scale === 'day') {
+    if (granularity === 'day') {
       // show "Last Day" => start = 1 day ago ~ end - 1 day
       startDate.setDate(endDate.getDate() - 1);
       const firstDataPoint = metricData?.filter(m => m?.type === 'hour')?.reverse()?.find((m) => fromIso(m?.date)?.getTime() > startDate?.getTime());
       return fromIso(firstDataPoint?.date);
-    } else if (scale === 'week') {
+    } else if (granularity === 'week') {
       // show "Last Week" => start = 7 days ago ~ end - 7 days
       startDate.setDate(endDate.getDate() - 7);
       const firstDataPoint = metricData?.filter(m => m?.type === 'hour')?.reverse()?.find((m) => fromIso(m?.date)?.getTime() > startDate?.getTime());
       return fromIso(firstDataPoint?.date);
-    } else if (scale === 'month') {
+    } else if (granularity === 'month') {
       // show "Last Month" => start = 1 month ago ~ end - 1 month
       startDate.setMonth(endDate.getMonth() - 1);
       const firstDataPoint = metricData?.filter(m => m?.type === 'hour')?.reverse()?.find((m) => fromIso(m?.date)?.getTime() > startDate?.getTime());
       return fromIso(firstDataPoint?.date);
-    } else if (scale === 'season') {
+    } else if (granularity === 'season') {
       // show "Last Season" => start = 3 months ago ~ end - 3 months
       startDate.setMonth(endDate.getMonth() - 3);
       const firstDataPoint = metricData?.filter(m => m?.type === 'hour')?.reverse()?.find((m) => fromIso(m?.date)?.getTime() > startDate?.getTime());
       return fromIso(firstDataPoint?.date);
-    } else if (scale === 'year') {
+    } else if (granularity === 'year') {
       // show "Last Year" => start = 1 year ago ~ end - 1 year
       startDate.setFullYear(endDate.getFullYear() - 1);
       const firstDataPoint = metricData?.filter(m => m?.type === 'hour')?.reverse()?.find((m) => fromIso(m?.date)?.getTime() > startDate?.getTime());
       return fromIso(firstDataPoint?.date);
-    } else if (scale === 'all') {
+    } else if (granularity === 'all') {
       return new Date(metricData?.filter(m => m?.type === 'hour')?.reverse()?.find(() => true)?.date.split(' ').join('T') + 'Z');
     }
     return startDate;
-  }
-
-  const historicalSlice = useMemo(() => {
-    const hourlyData = metricData?.filter(m => m?.type === 'hour')
-    const endDateIso = hourlyData?.find(() => true)?.date;
-    const endDate = fromIso(endDateIso);
-    const startDate = getStartDate(endDate, granularity);
-    return hourlyData?.filter(m =>
-      new Date(m?.date?.split(' ').join('T') + 'Z')?.getTime() > startDate?.getTime() && endDate?.getTime() < new Date(m?.date?.split(' ').join('T') + 'Z')?.getTime());
-  }, [metricData, granularity, getStartDate]);
-
+  }, [metricData, granularity]);
 
   function valuetext(value, length) {
     const offset = length - value;
@@ -214,11 +205,11 @@ export const HistoricalTimeslider = () => {
 
     const end = endDate.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
     //const startDate = new Date(data?.[data?.length - 1]?.date.split(' ').join('T') + 'Z');
-    const startDate = getStartDate(endDate, granularity);
+    const startDate = getStartDate(endDate);
     const start = startDate.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
 
     return [start, end];
-  }, [granularity, getStartDate]);
+  }, [getStartDate, metricData]);
 
   const numTicks = () => {
     const now = new Date();

--- a/src/components/VariablePanel/SensorBarChart.js
+++ b/src/components/VariablePanel/SensorBarChart.js
@@ -5,6 +5,8 @@ import {useEffect, useMemo, useRef, useState} from "react";
 import {FaChevronCircleLeft} from "react-icons/fa";
 import {FaChevronCircleRight} from "react-icons/fa";
 import {formatDate, LButton} from "./common";
+import {useDispatch} from "react-redux";
+import {setSelectedTimeIndex} from "../../store/slices/sensorDataSlice";
 
 
 const getIsoWeekRange = (year, weekNumber) => {
@@ -44,6 +46,7 @@ const shortDateFormat = new Intl.DateTimeFormat("en-US", {
 
 export const SensorBarChart = ({ context = 'recent', selectedParameter, margin = {left:30,top:30}, style = {}, showScroll = false, pageSize = 24, metricData, averageType }) => {
   const [page, setPage] = useState(0);
+  const dispatch = useDispatch();
 
   // Listen for changes to averageType or selectedParameter
   // Reset page number when averageType or selectedParameter changes
@@ -89,10 +92,22 @@ export const SensorBarChart = ({ context = 'recent', selectedParameter, margin =
 
   // Paging metadata: item count, number of pages, page number, page size, etc
   // TODO: how to calculate this with multiple parameters?
-  const itemsCount = metricData?.length;
-  const numPages = Math.ceil(itemsCount / pageSize);
+  const numItems = metricData?.length;
+  const numPages = Math.ceil(numItems / pageSize);
   const pageStart = useMemo(() => pageSize * (page), [page, pageSize]);
   const pageEnd = useMemo(() => pageSize * (page + 1), [page, pageSize]);
+  const isLastPage = useMemo(() => pageEnd === numItems, [numItems, pageEnd]);
+  const numItemsOnLastPage = useMemo(() => numItems % pageSize, [numItems, pageSize]);
+
+  const onBarClick = (d) => {
+    const size = context === 'historical' ? pageSize : 24;
+    const negativeOffset = d?.dataIndex;
+    const lastPageOffset = (numItemsOnLastPage || (size-1)) - negativeOffset;
+    const offset = isLastPage ? lastPageOffset : (size-1) - negativeOffset;
+    const index = pageStart + offset;
+    console.log('Selected:', index);
+    dispatch(setSelectedTimeIndex({ index }));
+  };
 
   // Filter the data and build a bar graph from it
   const filteredData = useMemo(() => metricData?.slice(pageStart, pageEnd)?.reverse(), [metricData, pageStart, pageEnd]);
@@ -243,7 +258,7 @@ export const SensorBarChart = ({ context = 'recent', selectedParameter, margin =
         </Grid>}
 
         {filteredData.length > 0 && <Grid size={showScroll ? 10 : 12}>
-          <BarChart {...chartSettings} margin={{...margin, top:20, }} />
+          <BarChart {...chartSettings} onItemClick={(event, d) => onBarClick(d)} margin={{...margin, top:20, }} />
         </Grid>}
 
         {showScroll && <Grid size={1}>

--- a/src/components/VariablePanel/SensorBarChart.js
+++ b/src/components/VariablePanel/SensorBarChart.js
@@ -5,8 +5,8 @@ import {useEffect, useMemo, useRef, useState} from "react";
 import {FaChevronCircleLeft} from "react-icons/fa";
 import {FaChevronCircleRight} from "react-icons/fa";
 import {formatDate, LButton} from "./common";
-import {useDispatch} from "react-redux";
-import {setSelectedTimeIndex} from "../../store/slices/sensorDataSlice";
+import {useDispatch, useSelector} from "react-redux";
+import {selectClickedSensor, selectMetricIndex, setSelectedTimeIndex} from "../../store/slices/sensorDataSlice";
 
 
 const getIsoWeekRange = (year, weekNumber) => {
@@ -47,11 +47,14 @@ const shortDateFormat = new Intl.DateTimeFormat("en-US", {
 export const SensorBarChart = ({ context = 'recent', selectedParameter, margin = {left:30,top:30}, style = {}, showScroll = false, pageSize = 24, metricData, averageType }) => {
   const [page, setPage] = useState(0);
   const dispatch = useDispatch();
+  const metricIndex = useSelector(selectMetricIndex);
+  const clickedSensor = useSelector(selectClickedSensor);
 
   // Listen for changes to averageType or selectedParameter
   // Reset page number when averageType or selectedParameter changes
   const prevType = useRef();
   const prevParam = useRef();
+  const prevSensor = useRef();
   useEffect(() => {
     if (prevType.current !== averageType) {
       prevType.current = averageType;
@@ -61,7 +64,11 @@ export const SensorBarChart = ({ context = 'recent', selectedParameter, margin =
       prevParam.current = selectedParameter;
       setPage(0);
     }
-  }, [averageType, selectedParameter]);
+    if (prevSensor.current !== clickedSensor) {
+      prevSensor.current = clickedSensor;
+      setPage(0);
+    }
+  }, [averageType, selectedParameter, clickedSensor]);
 
   const scrollBack = () => page > 0 && setPage(page - 1);
   const scrollForward = () => page < (numPages - 1) && setPage(page + 1);
@@ -79,15 +86,13 @@ export const SensorBarChart = ({ context = 'recent', selectedParameter, margin =
   }
 
   const getMaxValue = () => {
-    if (selectedParameter === 'nowcast_aqi') {
-      return 500;
-    } else if (selectedParameter === 'clarity_pm25' || selectedParameter === 'mean_pm25')  {
-      return 500;
-    } else if (selectedParameter === 'clarity_no2') {
-      return 1500;
-    } else {
-      return `ERR`;
-    }
+    // For all metrics on the current page, compute and return the max numerical value
+    return metricData
+      ?.slice(pageStart, pageEnd)
+      ?.reduce((max, m) => {
+        const value =  m?.value || m?.[selectedParameter];
+        return value > max ? value : max;
+      }, -Infinity);
   };
 
   // Paging metadata: item count, number of pages, page number, page size, etc
@@ -104,8 +109,13 @@ export const SensorBarChart = ({ context = 'recent', selectedParameter, margin =
     const negativeOffset = d?.dataIndex;
     const lastPageOffset = (numItemsOnLastPage || (size-1)) - negativeOffset;
     const offset = isLastPage ? lastPageOffset : (size-1) - negativeOffset;
-    const index = pageStart + offset;
+
+    // Now include metricIndex (to support everything but averageType=day)
+    const averageTypeOffset = pageStart + offset;
+    const averageTypeStart = metricIndex[averageType];
+    const index = averageTypeStart + averageTypeOffset
     console.log('Selected:', index);
+
     dispatch(setSelectedTimeIndex({ index }));
   };
 
@@ -135,7 +145,7 @@ export const SensorBarChart = ({ context = 'recent', selectedParameter, margin =
       disableTicks: true,
       position: 'none',  // Hides the Y-Axis, since bars have individual values
       width: 60,
-      max: getMaxValue(),
+      max: getMaxValue() + 100,
       colorMap: {
         type: 'piecewise',
         thresholds: pm2_5Ranges?.map(r => {

--- a/src/constants/defaults.js
+++ b/src/constants/defaults.js
@@ -56,6 +56,7 @@ export const INITIAL_STATE = {
   },
   panelState: {
     variables: window.innerWidth > 768,
+    history: true,
     info: true,
     key: window.innerWidth > 768,
     tutorial: false,

--- a/src/store/slices/legacyStoreSlice.js
+++ b/src/store/slices/legacyStoreSlice.js
@@ -408,6 +408,7 @@ export const legacyStoreSlice = createSlice({
     selectUrlParams: state => state.urlParams,
 
     // Helper accessors for common panels
+    selectHistoryPanelState: state => state.panelState.history,
     selectVariablePanelState: state => state.panelState.variables,
     selectDataPanelState: state => state.panelState.info,
 

--- a/src/store/slices/sensorDataSlice.js
+++ b/src/store/slices/sensorDataSlice.js
@@ -24,6 +24,7 @@ const initialState = {
 
   // User selections
   breadcrumbs: ['root'],
+  selectedTimeIndex: 0,
   selectedAreas: {
     community: [],
     zip: [],
@@ -40,6 +41,10 @@ export const sensorDataSlice = createSlice({
   name: 'sensors',
   initialState,
   reducers: {
+    setSelectedTimeIndex: (state, action) => ({
+      ...state,
+      selectedTimeIndex: action.payload.index
+    }),
     setBreadcrumbs: (state, action) => ({
       ...state,
       breadcrumbs: action.payload
@@ -149,6 +154,7 @@ export const sensorDataSlice = createSlice({
     },
   },
   selectors: {
+    selectSelectedTimeIndex: state => state.selectedTimeIndex,
     selectSensorLocations: state => state.locations,
     selectSelectedSensors: state => state.selectedSensors,
     selectSensorGeojsonData: state => state.geojsonData,
@@ -180,6 +186,7 @@ export const {
   setMetricIndex,
   setMetricData,
   setBreadcrumbs,
+  setSelectedTimeIndex,
 } = sensorDataSlice.actions;
 
 // useSelector + a selector to read the state
@@ -195,6 +202,7 @@ export const {
   selectMetricIndex,
   selectMetricData,
   selectMetrics,
-  selectBreadcrumbs
+  selectBreadcrumbs,
+  selectSelectedTimeIndex,
 } = sensorDataSlice.selectors
 


### PR DESCRIPTION
## Problem
We would like a way to visualize past sensor data using the map

Fixes #44 

## Approach
* feat: proof-of-concept for selecting a slice of historical data from the bar chart and showing it on the map
* style: slight transparency adjustment for sensor points on the map

TODOs:
* implement using the designs/styles as outlined by @shubhamk008 (e.g. widget to select a timestamp, how to visually indicate to the user that a time index has been selected, how to prompt them to clear it when they are done, etc)
* investigate edge cases - e.g. switching back to latest, page w/ 1 bar, single page or bars, etc

## How to Test
1. Navigate to https://deploy-preview-150--stirring-alpaca-574101.netlify.app/map
2. Click on a sensor point
    * You should see that the DataPanel offers a bar graph
3. Click on bar in the graph
    * You should see that the sensor points on the map are re-colored to show the data visually for the chosen time


### Screenshots
<img width="1351" height="815" alt="Screenshot 2026-07-06 at 1 20 34 PM" src="https://github.com/user-attachments/assets/4f1e8d6a-ba38-4a10-91a0-f64e34509ff5" />

<img width="1448" height="819" alt="Screenshot_2026-07-06_at_1_20_48 PM" src="https://github.com/user-attachments/assets/fa405cef-2579-4fe0-8783-a4179eb7b1c4" />

