### PR TITLE
style: relative historical graph bar height

### DIFF
--- a/src/components/Map/DataPanel.js
+++ b/src/components/Map/DataPanel.js
@@ -37,7 +37,7 @@ import {MdHomeFilled} from "react-icons/md";
 
 const DataPanelContainer = styled.div`
     position: fixed;
-    width: ${({ $large }) => $large ? '433px' : '100%'};
+    width: ${({ $large }) => $large ? '500px' : '100%'};
     top: ${({ $large }) => $large ? '2rem' : ''};
     bottom: ${({ $large }) => $large ? '' : '0'};
     left: ${({ $large }) => $large ? '' : '0'};

--- a/src/components/VariablePanel/SensorBarChart.js
+++ b/src/components/VariablePanel/SensorBarChart.js
@@ -76,15 +76,13 @@ export const SensorBarChart = ({ context = 'recent', selectedParameter, margin =
   }
 
   const getMaxValue = () => {
-    if (selectedParameter === 'nowcast_aqi') {
-      return 500;
-    } else if (selectedParameter === 'clarity_pm25' || selectedParameter === 'mean_pm25')  {
-      return 500;
-    } else if (selectedParameter === 'clarity_no2') {
-      return 1500;
-    } else {
-      return `ERR`;
-    }
+    // For all metrics on the current page, compute and return the max numerical value
+    return metricData
+      ?.slice(pageStart, pageEnd)
+      ?.reduce((max, m) => {
+        const value =  m?.value || m?.[selectedParameter];
+        return value > max ? value : max;
+      }, -Infinity);
   };
 
   // Paging metadata: item count, number of pages, page number, page size, etc
@@ -120,7 +118,7 @@ export const SensorBarChart = ({ context = 'recent', selectedParameter, margin =
       disableTicks: true,
       position: 'none',  // Hides the Y-Axis, since bars have individual values
       width: 60,
-      max: getMaxValue(),
+      max: getMaxValue() + 100,
       colorMap: {
         type: 'piecewise',
         thresholds: pm2_5Ranges?.map(r => {


### PR DESCRIPTION
## Problem
We would like graph bar height to adjust based on the max values of the bars being shown

This would make it easier to see visible trends in the graph

## Approach
* style: relative bar height based on max value being shown
* style: increase width of the DataPanel

<img width="529" height="639" alt="Screenshot 2026-07-30 at 11 38 08 AM" src="https://github.com/user-attachments/assets/6751bf24-1f01-42ad-9a53-42685c6e915a" />

## How to Test
1. Navigate to /map
2. Click on a sensor on the map
    * You should see that the DataPanel is shown
    * You should see that the DataPanel is now wide enough to display the full `AQI-PM2.5` indicator name
3. Click on the "Details" button
    * You should see the Historical Trends graph appear
    * You should see that bars in this graph are generally taller even if they contain smaller numbers

