### PR TITLE
style: skip inverting color for sensor value color indicator

### DIFF
--- a/src/components/VariablePanel/SensorValueDisplay.js
+++ b/src/components/VariablePanel/SensorValueDisplay.js
@@ -98,7 +98,7 @@ export const SensorValueDisplay = ({ showColor = true, style, value }) => {
 
         {/* Show latest reading */}
         {!!rounded && <Grid container spacing={0} alignItems={'center'}>
-          {showColor && <SensorValueColorIndicator $color={primary} $border={secondary}></SensorValueColorIndicator>}
+          {showColor && <SensorValueColorIndicator $color={range?.color} $border={range?.border}></SensorValueColorIndicator>}
           <Grid>
             <SensorNumericalValue $color={rounded ? primary : 'rgba(68, 68, 68, 0.75)'}>
               {selectedParameter === 'nowcast_aqi' && Number(rounded)}

--- a/src/components/VariablePanel/SensorValueDisplay.js
+++ b/src/components/VariablePanel/SensorValueDisplay.js
@@ -65,7 +65,7 @@ export const SensorValueDisplay = ({ showColor = true, style, value }) => {
   const invertedColors = ['Good', 'Moderate'];
 
   const primary = invertedColors?.includes(range?.label) ? range?.border : range?.color;
-  const secondary = invertedColors?.includes(range?.label) ? range?.color : range?.border;
+  //const secondary = invertedColors?.includes(range?.label) ? range?.color : range?.border;
 
   return (
     <>


### PR DESCRIPTION
## Problem
When selecting a sensor, we invert the color/border values for green + yellow

This was originally done to match the color of the selected point on the map, but it doesnt necessarily make sense to users that the color no longer matches the Legend

## Approach
* style: dont invert color for value color indicator, only invert text color

<img width="507" height="396" alt="Screenshot 2026-08-11 at 11 56 55 AM" src="https://github.com/user-attachments/assets/f6601538-6074-4519-ae2c-03e510fd3ec4" />

## How to Test
1. Navigate to /map
2. Click on a sensor (either green or yellow)
    * You should see the DataPanel on the right shows the current value for this sensor
    * You should see that the color is no longer inverted for green or yellow values, so they should match the Legend