### PR TITLE
fix: SensorBarChart for PM2.5 and NO2 + add formal title for AQColorScale

### DIFF
--- a/src/components/VariablePanel/AQColorScale.js
+++ b/src/components/VariablePanel/AQColorScale.js
@@ -126,7 +126,7 @@ export const AQColorScale = () => {
     <ColorScaleContainer $large={largeScreen} $open={panelState.key}>
       <Grid container spacing={0} style={{ fontFamily: 'Lexend', fontWeight: 200 }} justifyContent={'center'}>
         <Grid justifyContent={'end'}>
-          {selectedParameter === 'nowcast_aqi' && <LHeader>Nowcast AQI for PM2.5 </LHeader>}
+          {selectedParameter === 'nowcast_aqi' && <LHeader>EPA Particulate Matter Index</LHeader>}
           {selectedParameter === 'clarity_pm25' && <LHeader>Fine Particulate Matter</LHeader>}
           {selectedParameter === 'clarity_no2' && <LHeader>Nitrogen Dioxide</LHeader>}
         </Grid>

--- a/src/components/VariablePanel/AQColorScale.js
+++ b/src/components/VariablePanel/AQColorScale.js
@@ -8,6 +8,7 @@ import {selectPanelState, setPanelState} from "../../store/slices/legacyStoreSli
 import {useDispatch, useSelector} from "react-redux";
 import {FaKey} from "react-icons/fa";
 import {selectSensorParameter} from "../../store/slices/sensorDataSlice";
+import {LHeader} from "./common";
 
 //// Styled components CSS
 // Main container for entire panel
@@ -123,7 +124,14 @@ export const AQColorScale = () => {
 
   return (
     <ColorScaleContainer $large={largeScreen} $open={panelState.key}>
-      <Grid container spacing={0} style={{ fontFamily: 'Lexend', fontWeight: 200, marginBottom: '1rem' }}>
+      <Grid container spacing={0} style={{ fontFamily: 'Lexend', fontWeight: 200 }} justifyContent={'center'}>
+        <Grid justifyContent={'end'}>
+          {selectedParameter === 'nowcast_aqi' && <LHeader>Nowcast AQI for PM2.5 </LHeader>}
+          {selectedParameter === 'clarity_pm25' && <LHeader>Fine Particulate Matter</LHeader>}
+          {selectedParameter === 'clarity_no2' && <LHeader>Nitrogen Dioxide</LHeader>}
+        </Grid>
+      </Grid>
+      <Grid container spacing={0} style={{ fontFamily: 'Lexend', fontWeight: 200, marginBottom: '1rem', marginTop:'0.5rem' }}>
         {selectedParameter === 'nowcast_aqi' && <Grid size={3} style={{ textAlign: 'right' }}>
           <Tooltip arrow={true} placement={'top'} style={{ textDecoration: 'underline', textDecorationStyle: 'dotted' }} title={'EPA’s Air Quality Index (AQI)'}>AQI-PM2.5</Tooltip>
         </Grid>}

--- a/src/components/VariablePanel/SensorBarChart.js
+++ b/src/components/VariablePanel/SensorBarChart.js
@@ -82,7 +82,7 @@ export const SensorBarChart = ({ context = 'recent', selectedParameter, margin =
       ?.reduce((max, m) => {
         const value =  m?.value || m?.[selectedParameter];
         return value > max ? value : max;
-      }, -Infinity);
+      }, -Infinity) + (selectedParameter === 'nowcast_aqi' ? 100 : 30);
   };
 
   // Paging metadata: item count, number of pages, page number, page size, etc
@@ -118,7 +118,7 @@ export const SensorBarChart = ({ context = 'recent', selectedParameter, margin =
       disableTicks: true,
       position: 'none',  // Hides the Y-Axis, since bars have individual values
       width: 60,
-      max: getMaxValue() + 100,
+      max: getMaxValue(),
       colorMap: {
         type: 'piecewise',
         thresholds: pm2_5Ranges?.map(r => {


### PR DESCRIPTION
## Problem
SensorBarChart should use more of its real estate to display the bar chart values

AQI does this as expected, but PM2.5 and NO2 do not and still have smaller looking bars

## Approach
* fix: SensorBarChart - adjust max height for PM2.5 / NO2 sensor bar chart.. hardcoded offset of `100` (used to prevent bar values from extending out of view) was too high for these cases, use `30` for these indicators instead instead
* feat: AQColorScale added a formal title above the color scale

## How to Test
1. Navigate to /map
2. Click on a sensor on the map
    * You should see the SensorBarChart appears in the data panel
3. From the Indicaotr dropdown, choose either `PM2.5` or `NO2`
    * For both cases, you should see that the bars take up slightly more of the space on the graph now


### SensorBarChart Screenshots
<img width="506" height="395" alt="Screenshot 2026-08-12 at 12 35 53 AM" src="https://github.com/user-attachments/assets/1f83d1b0-dd5d-4c49-8686-cecb66e129ad" />
<img width="503" height="392" alt="Screenshot 2026-08-12 at 12 39 21 AM" src="https://github.com/user-attachments/assets/4244ed71-7dc8-408b-ab29-8eae0ed0915c" />


### AQColorScale Screenshots
<img width="444" height="299" alt="Screenshot 2026-08-12 at 1 04 44 AM" src="https://github.com/user-attachments/assets/062d63ab-d296-4415-8251-42cf227c6378" />
<img width="440" height="300" alt="Screenshot 2026-08-12 at 1 03 28 AM" src="https://github.com/user-attachments/assets/a5d3eb66-9c62-4264-80af-55a355c0263d" />
<img width="454" height="299" alt="Screenshot 2026-08-12 at 1 04 49 AM" src="https://github.com/user-attachments/assets/da825202-74b3-436d-ab85-30c99a8a79da" />

